### PR TITLE
feature: deploy to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,24 @@ let package = Package(
     platforms: [
         .iOS(.v17),
         .macOS(.v14),
-        .tvOS(.v17),
-        .watchOS(.v10)
+        .tvOS(.v17)
     ],
     products: [
-        .library(name: "Votice", targets: ["Votice"])
+        .library(
+            name: "VoticeSDK",
+            targets: ["VoticeSDK"]
+        )
     ],
     targets: [
-        .target(name: "Votice", path: "Sources/Votice"),
-        .testTarget(name: "VoticeTests", dependencies: ["Votice"], path: "Tests/VoticeTests")
+        .target(
+            name: "VoticeSDK",
+            path: "Sources/Votice"
+        ),
+        .testTarget(
+            name: "VoticeTests",
+            dependencies: ["VoticeSDK"],
+            path: "Tests/VoticeTests"
+        )
     ]
 )
 ```

--- a/Tests/VoticeTests/Managers/ConfigurationManagerTests.swift
+++ b/Tests/VoticeTests/Managers/ConfigurationManagerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
 import Foundation
 
 // MARK: - ConfigurationManager Tests

--- a/Tests/VoticeTests/Managers/DeviceManagerTests.swift
+++ b/Tests/VoticeTests/Managers/DeviceManagerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
 import Foundation
 
 // MARK: - DeviceManager Tests

--- a/Tests/VoticeTests/Managers/FontManagerTests.swift
+++ b/Tests/VoticeTests/Managers/FontManagerTests.swift
@@ -7,8 +7,8 @@
 //
 
 import Testing
+@testable import VoticeSDK
 import SwiftUI
-@testable import Votice
 
 @Suite("FontManager Tests")
 struct FontManagerTests {

--- a/Tests/VoticeTests/Managers/LogManagerTests.swift
+++ b/Tests/VoticeTests/Managers/LogManagerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
 import Foundation
 
 @Test("LogManager should handle different log types")

--- a/Tests/VoticeTests/Managers/NetworkManagerTests.swift
+++ b/Tests/VoticeTests/Managers/NetworkManagerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
 import Foundation
 
 // MARK: - Mock URLSession Protocol

--- a/Tests/VoticeTests/Managers/TextManagerTests.swift
+++ b/Tests/VoticeTests/Managers/TextManagerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
 import Foundation
 
 // MARK: - Mock Texts Implementation

--- a/Tests/VoticeTests/Managers/VoticeFontConfigurationTests.swift
+++ b/Tests/VoticeTests/Managers/VoticeFontConfigurationTests.swift
@@ -7,7 +7,8 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
+import Foundation
 
 @Suite("VoticeFontConfiguration Tests")
 struct VoticeFontConfigurationTests {

--- a/Tests/VoticeTests/Models/CommentEntityTests.swift
+++ b/Tests/VoticeTests/Models/CommentEntityTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
 import Foundation
 
 // MARK: - CommentEntity Tests

--- a/Tests/VoticeTests/Models/SuggestionEntityTests.swift
+++ b/Tests/VoticeTests/Models/SuggestionEntityTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
 import Foundation
 
 // MARK: - SuggestionEntity Tests

--- a/Tests/VoticeTests/Models/SuggestionSourceTests.swift
+++ b/Tests/VoticeTests/Models/SuggestionSourceTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Testing
-@testable import Votice
+@testable import VoticeSDK
 import Foundation
 
 // MARK: - SuggestionSource Tests

--- a/Tests/VoticeTests/VoticeTests.swift
+++ b/Tests/VoticeTests/VoticeTests.swift
@@ -6,8 +6,8 @@
 //  Copyright ArtCC. All rights reserved.
 
 import Testing
+@testable import VoticeSDK
 import SwiftUI
-@testable import Votice
 
 @Suite("Votice Tests")
 struct VoticeTests {


### PR DESCRIPTION
This pull request updates the package name and associated references across the codebase to rename `Votice` to `VoticeSDK`. The changes include adjustments to the package manifest, test files, and import statements.

### Package Manifest Updates:
* Renamed the library name from `Votice` to `VoticeSDK` in the `products` section of the package manifest.
* Updated the `targets` section to reflect the new name `VoticeSDK` for both the main target and test target.

### Test File Updates:
* Updated `@testable import` statements in multiple test files to reference `VoticeSDK` instead of `Votice`. This change affects the following files:
  - `ConfigurationManagerTests.swift`
  - `DeviceManagerTests.swift`
  - `FontManagerTests.swift`
  - `LogManagerTests.swift`
  - `NetworkManagerTests.swift`
  - `TextManagerTests.swift`
  - `VoticeFontConfigurationTests.swift`
  - `CommentEntityTests.swift`
  - `SuggestionEntityTests.swift`
  - `SuggestionSourceTests.swift`
  - `VoticeTests.swift`