### PR TITLE
feature: update Votice SDK version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Votice management app for handling suggestions and apps is available for dow
 Add this line to your `Package.swift` dependencies:
 
 ```swift
-.package(url: "https://github.com/artcc/votice-sdk", from: "1.0.0"),
+.package(url: "https://github.com/artcc/votice-sdk", from: "1.0.1"),
 ```
 
 Or via Xcode:


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file to reflect a new version of the `votice-sdk` dependency.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37): Updated the `Package.swift` dependency to use version `1.0.1` of `votice-sdk` instead of `1.0.0`.