### PR TITLE
feature: deploy v1.0.3 to main branch

### DIFF
--- a/Example/VoticeDemo/VoticeDemo/Shared/SpanishTexts.swift
+++ b/Example/VoticeDemo/VoticeDemo/Shared/SpanishTexts.swift
@@ -16,13 +16,14 @@ struct SpanishTexts: VoticeTextsProtocol {
 
     let cancel = "Cancelar"
     let error = "Error"
-    let ok = "OK"
+    let ok = "Ok"
     let submit = "Enviar"
     let optional = "Opcional"
     let success = "Éxito"
     let warning = "Advertencia"
     let info = "Información"
     let genericError = "Algo salió mal. Por favor, inténtalo de nuevo."
+    let anonymous = "Anónimo"
 
     // MARK: - Suggestion List
 

--- a/Sources/Votice/Core/Managers/TextManager.swift
+++ b/Sources/Votice/Core/Managers/TextManager.swift
@@ -24,6 +24,7 @@ public protocol VoticeTextsProtocol: Sendable {
     var warning: String { get }
     var info: String { get }
     var genericError: String { get }
+    var anonymous: String { get }
 
     // MARK: - Suggestion List
 
@@ -91,13 +92,14 @@ public struct DefaultVoticeTexts: VoticeTextsProtocol {
 
     public let cancel = "Cancel"
     public let error = "Error"
-    public let ok = "OK"
+    public let ok = "Ok"
     public let submit = "Submit"
     public let optional = "Optional"
     public let success = "Success"
     public let warning = "Warning"
     public let info = "Info"
     public let genericError = "Something went wrong. Please try again."
+    public let anonymous = "Anonymous"
 
     // MARK: - Suggestion List
 

--- a/Sources/Votice/Core/Models/CommentEntity.swift
+++ b/Sources/Votice/Core/Models/CommentEntity.swift
@@ -23,7 +23,7 @@ struct CommentEntity: Codable, Sendable, Identifiable {
 
 extension CommentEntity {
     var displayName: String {
-        return nickname ?? "Anonymous"
+        return nickname ?? TextManager.shared.texts.anonymous
     }
     var isFromSDK: Bool {
         return deviceId != nil

--- a/Sources/Votice/Core/Models/VoticeAlertEntity.swift
+++ b/Sources/Votice/Core/Models/VoticeAlertEntity.swift
@@ -27,35 +27,35 @@ struct VoticeAlertEntity {
         self.type = type
         self.title = title
         self.message = message
-        self.primaryButton = primaryButton ?? VoticeAlertButton(title: "OK", style: .default)
+        self.primaryButton = primaryButton ?? VoticeAlertButton(title: TextManager.shared.texts.ok, style: .default)
         self.secondaryButton = secondaryButton
     }
 
     // MARK: - Convenience Initializers
 
-    static func error(title: String = "Error",
+    static func error(title: String = TextManager.shared.texts.error,
                       message: String,
                       okAction: @escaping () -> Void = {}) -> VoticeAlertEntity {
         VoticeAlertEntity(
             type: .error,
             title: title,
             message: message,
-            primaryButton: VoticeAlertButton(title: "OK", style: .destructive, action: okAction)
+            primaryButton: VoticeAlertButton(title: TextManager.shared.texts.ok, style: .destructive, action: okAction)
         )
     }
 
-    static func success(title: String = "Success",
+    static func success(title: String = TextManager.shared.texts.success,
                         message: String,
                         okAction: @escaping () -> Void = {}) -> VoticeAlertEntity {
         VoticeAlertEntity(
             type: .success,
             title: title,
             message: message,
-            primaryButton: VoticeAlertButton(title: "OK", style: .primary, action: okAction)
+            primaryButton: VoticeAlertButton(title: TextManager.shared.texts.ok, style: .primary, action: okAction)
         )
     }
 
-    static func warning(title: String = "Warning",
+    static func warning(title: String = TextManager.shared.texts.warning,
                         message: String,
                         okAction: @escaping () -> Void = {},
                         cancelAction: @escaping () -> Void = {}) -> VoticeAlertEntity {
@@ -63,19 +63,21 @@ struct VoticeAlertEntity {
             type: .warning,
             title: title,
             message: message,
-            primaryButton: VoticeAlertButton(title: "OK", style: .primary, action: okAction),
-            secondaryButton: VoticeAlertButton(title: "Cancel", style: .default, action: cancelAction)
+            primaryButton: VoticeAlertButton(title: TextManager.shared.texts.ok, style: .primary, action: okAction),
+            secondaryButton: VoticeAlertButton(title: TextManager.shared.texts.cancel,
+                                               style: .default,
+                                               action: cancelAction)
         )
     }
 
-    static func info(title: String = "Info",
+    static func info(title: String = TextManager.shared.texts.info,
                      message: String,
                      okAction: @escaping () -> Void = {}) -> VoticeAlertEntity {
         VoticeAlertEntity(
             type: .info,
             title: title,
             message: message,
-            primaryButton: VoticeAlertButton(title: "OK", style: .default, action: okAction)
+            primaryButton: VoticeAlertButton(title: TextManager.shared.texts.ok, style: .default, action: okAction)
         )
     }
 }

--- a/Sources/Votice/UI/Components/VoticeAlert.swift
+++ b/Sources/Votice/UI/Components/VoticeAlert.swift
@@ -50,7 +50,7 @@ private extension VoticeAlert {
                 .fill(theme.colors.surface)
                 .shadow(color: Color.black.opacity(0.15), radius: 20, x: 0, y: 10)
         )
-        .padding(theme.spacing.lg)
+        .padding(theme.spacing.md)
         .frame(maxWidth: 320)
     }
 
@@ -65,13 +65,13 @@ private extension VoticeAlert {
                     .foregroundColor(alertTypeColor)
             }
             Text(alert.title)
-                .font(theme.typography.title2)
-                .fontWeight(.bold)
+                .font(theme.typography.title3)
+                .fontWeight(.semibold)
                 .foregroundColor(theme.colors.onSurface)
                 .multilineTextAlignment(.center)
         }
-        .padding(.top, theme.spacing.lg)
-        .padding(.horizontal, theme.spacing.lg)
+        .padding(.top, theme.spacing.md)
+        .padding(.horizontal, theme.spacing.md)
     }
 
     var contentSection: some View {
@@ -83,8 +83,7 @@ private extension VoticeAlert {
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .padding(.horizontal, theme.spacing.lg)
-        .padding(.vertical, theme.spacing.md)
+        .padding(theme.spacing.md)
     }
 
     var buttonsSection: some View {
@@ -96,12 +95,12 @@ private extension VoticeAlert {
                     alertButton(secondaryButton, isPrimary: false)
                     alertButton(alert.primaryButton, isPrimary: true)
                 }
-                .padding(.horizontal, theme.spacing.lg)
-                .padding(.bottom, theme.spacing.lg)
+                .padding(.horizontal, theme.spacing.md)
+                .padding(.bottom, theme.spacing.md)
             } else {
                 alertButton(alert.primaryButton, isPrimary: true)
-                    .padding(.horizontal, theme.spacing.lg)
-                    .padding(.bottom, theme.spacing.lg)
+                    .padding(.horizontal, theme.spacing.md)
+                    .padding(.bottom, theme.spacing.md)
             }
         }
     }
@@ -147,7 +146,7 @@ private extension VoticeAlert {
                 .fontWeight(isPrimary ? .semibold : .medium)
                 .foregroundColor(buttonTextColor(for: button.style, isPrimary: isPrimary))
                 .frame(maxWidth: .infinity)
-                .frame(height: 44)
+                .frame(height: 40)
                 .background(
                     RoundedRectangle(cornerRadius: theme.cornerRadius.md)
                         .fill(buttonBackgroundColor(for: button.style, isPrimary: isPrimary))

--- a/Tests/VoticeTests/Managers/TextManagerTests.swift
+++ b/Tests/VoticeTests/Managers/TextManagerTests.swift
@@ -24,6 +24,7 @@ struct MockVoticeTexts: VoticeTextsProtocol {
     let warning = "Advertencia"
     let info = "Información"
     let genericError = "Algo salió mal. Por favor, inténtalo de nuevo."
+    let anonymous = "Anónimo"
 
     // MARK: - Suggestion List
 
@@ -97,13 +98,14 @@ func testTextManagerInitialization() async {
     // Then
     #expect(texts.cancel == "Cancel")
     #expect(texts.error == "Error")
-    #expect(texts.ok == "OK")
+    #expect(texts.ok == "Ok")
     #expect(texts.submit == "Submit")
     #expect(texts.optional == "Optional")
     #expect(texts.success == "Success")
     #expect(texts.warning == "Warning")
     #expect(texts.info == "Info")
     #expect(texts.genericError == "Something went wrong. Please try again.")
+    #expect(texts.anonymous == "Anonymous")
     #expect(texts.loadingSuggestions == "Loading suggestions...")
     #expect(texts.featureRequests == "Feature Requests")
     #expect(texts.newSuggestion == "New Suggestion")
@@ -150,7 +152,7 @@ func testTextManagerResetToDefault() async {
     // Then
     #expect(resetTexts.cancel == "Cancel")
     #expect(resetTexts.error == "Error")
-    #expect(resetTexts.ok == "OK")
+    #expect(resetTexts.ok == "Ok")
     #expect(resetTexts.submit == "Submit")
     #expect(resetTexts.optional == "Optional")
     #expect(resetTexts.loadingSuggestions == "Loading suggestions...")
@@ -234,6 +236,7 @@ func testTextManagerMultipleUpdates() async {
         let warning = "Warning"
         let info = "Info"
         let genericError = "Something went wrong. Please try again."
+        let anonymous = "Anonyme"
         let loadingSuggestions = "Chargement des suggestions..."
         let noSuggestionsYet = "Pas encore de suggestions."
         let beFirstToSuggest = "Soyez le premier à suggérer quelque chose!"
@@ -298,7 +301,7 @@ func testTextManagerMultipleUpdates() async {
     let finalTexts = manager.texts
     #expect(finalTexts.cancel == "Cancel")
     #expect(finalTexts.error == "Error")
-    #expect(finalTexts.ok == "OK")
+    #expect(finalTexts.ok == "Ok")
 }
 // swiftlint:enable function_body_length
 
@@ -312,13 +315,14 @@ func testDefaultVoticeTexts() async {
     // Then - General
     #expect(texts.cancel == "Cancel")
     #expect(texts.error == "Error")
-    #expect(texts.ok == "OK")
+    #expect(texts.ok == "Ok")
     #expect(texts.submit == "Submit")
     #expect(texts.optional == "Optional")
     #expect(texts.success == "Success")
     #expect(texts.warning == "Warning")
     #expect(texts.info == "Info")
     #expect(texts.genericError == "Something went wrong. Please try again.")
+    #expect(texts.anonymous == "Anonymous")
 
     // Suggestion List
     #expect(texts.loadingSuggestions == "Loading suggestions...")

--- a/Tests/VoticeTests/VoticeTests.swift
+++ b/Tests/VoticeTests/VoticeTests.swift
@@ -142,6 +142,7 @@ struct VoticeTests {
             let warning = "Mock Warning"
             let info = "Mock Info"
             let genericError = "Mock Generic Error"
+            let anonymous = "Mock Anonymous"
             let loadingSuggestions = "Mock Loading"
             let noSuggestionsYet = "Mock No Suggestions"
             let beFirstToSuggest = "Mock Be First"


### PR DESCRIPTION
This pull request introduces updates to text management and UI styling in the Votice codebase. Key changes include the addition of an `anonymous` text property to the `VoticeTextsProtocol`, updates to text references in alert entities, and adjustments to the VoticeAlert UI components for improved consistency and design.

### Text Management Updates:
* Added `anonymous` property to `VoticeTextsProtocol` and its implementations (`DefaultVoticeTexts`, `SpanishTexts`, `MockVoticeTexts`) to standardize the use of "Anonymous" across the codebase. [[1]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R27) [[2]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3L94-R102) [[3]](diffhunk://#diff-cbe19f9ad04daaf6e72337dfd00d1cb78fa68aaf5cd95614b7ae3f3a21f49035L19-R26) [[4]](diffhunk://#diff-c9a288bdf47ac463f6549ca0d736a88bf12f283302ebf5f676717625f36913c6R27)
* Updated `CommentEntity` to use `TextManager.shared.texts.anonymous` instead of hardcoding "Anonymous" for better localization support.
* Modified unit tests to validate the new `anonymous` property and updated expectations for the `ok` text property. [[1]](diffhunk://#diff-c9a288bdf47ac463f6549ca0d736a88bf12f283302ebf5f676717625f36913c6L100-R108) [[2]](diffhunk://#diff-c9a288bdf47ac463f6549ca0d736a88bf12f283302ebf5f676717625f36913c6L153-R155) [[3]](diffhunk://#diff-c9a288bdf47ac463f6549ca0d736a88bf12f283302ebf5f676717625f36913c6R239) [[4]](diffhunk://#diff-c9a288bdf47ac463f6549ca0d736a88bf12f283302ebf5f676717625f36913c6L301-R304) [[5]](diffhunk://#diff-c9a288bdf47ac463f6549ca0d736a88bf12f283302ebf5f676717625f36913c6L315-R325) [[6]](diffhunk://#diff-87349ddd43fdd9f05e65bb198c8fe37117f224f2529ae58d708948addd755292R145)

### Alert Entity Text Updates:
* Replaced hardcoded alert texts (e.g., "OK", "Error", "Success") with references to `TextManager.shared.texts` for improved localization and consistency.

### UI Styling Adjustments:
* Updated padding and typography in `VoticeAlert` components to align with design guidelines, including reducing padding sizes and changing font styles for titles. [[1]](diffhunk://#diff-3e4847a110696fc2ec6a7cfc11cc8cc34f9209db326a69be3fb00b2dc556029bL53-R53) [[2]](diffhunk://#diff-3e4847a110696fc2ec6a7cfc11cc8cc34f9209db326a69be3fb00b2dc556029bL68-R74) [[3]](diffhunk://#diff-3e4847a110696fc2ec6a7cfc11cc8cc34f9209db326a69be3fb00b2dc556029bL86-R86) [[4]](diffhunk://#diff-3e4847a110696fc2ec6a7cfc11cc8cc34f9209db326a69be3fb00b2dc556029bL99-R103) [[5]](diffhunk://#diff-3e4847a110696fc2ec6a7cfc11cc8cc34f9209db326a69be3fb00b2dc556029bL150-R149)