### PR TITLE
feature: deploy to main branch v1.0.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,16 @@ jobs:
     - name: Select Xcode Version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.2'
+        xcode-version: 'latest-stable'
 
     - name: List available simulators
-      run: xcrun simctl list devices --json | jq '.devices | to_entries[] | select(.key | contains("iOS")) | .key'
+      run: |
+        echo "=== Xcode version ==="
+        xcodebuild -version
+        echo "=== Available iOS Simulators ==="
+        xcrun simctl list devices ios
+        echo "=== Available destinations ==="
+        xcodebuild -project Example/VoticeDemo/VoticeDemo.xcodeproj -scheme VoticeDemo -showdestinations
 
     - name: Build and Test Swift Package
       run: swift test --verbose
@@ -30,33 +36,12 @@ jobs:
     - name: Build iOS Example
       run: |
         cd Example/VoticeDemo
-        
-        # Try with iPhone 15 first
-        if xcodebuild -project VoticeDemo.xcodeproj \
-                      -scheme VoticeDemo \
-                      -destination 'platform=iOS Simulator,name=iPhone 15' \
-                      build \
-                      CODE_SIGN_IDENTITY="" \
-                      CODE_SIGNING_REQUIRED=NO; then
-          echo "Build successful with iPhone 15"
-        # Fallback to iPhone 14 if iPhone 15 is not available
-        elif xcodebuild -project VoticeDemo.xcodeproj \
-                        -scheme VoticeDemo \
-                        -destination 'platform=iOS Simulator,name=iPhone 14' \
-                        build \
-                        CODE_SIGN_IDENTITY="" \
-                        CODE_SIGNING_REQUIRED=NO; then
-          echo "Build successful with iPhone 14"
-        # Final fallback to any iOS simulator
-        else
-          echo "Trying with any available iOS simulator..."
-          xcodebuild -project VoticeDemo.xcodeproj \
-                     -scheme VoticeDemo \
-                     -destination 'generic/platform=iOS Simulator' \
-                     build \
-                     CODE_SIGN_IDENTITY="" \
-                     CODE_SIGNING_REQUIRED=NO
-        fi
+        xcodebuild -project VoticeDemo.xcodeproj \
+                   -scheme VoticeDemo \
+                   -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+                   build \
+                   CODE_SIGN_IDENTITY="" \
+                   CODE_SIGNING_REQUIRED=NO
 
   release:
     name: Create Tag and Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,42 @@ jobs:
       with:
         xcode-version: '16.2'
 
+    - name: List available simulators
+      run: xcrun simctl list devices --json | jq '.devices | to_entries[] | select(.key | contains("iOS")) | .key'
+
     - name: Build and Test Swift Package
       run: swift test --verbose
+
+    - name: Build iOS Example
+      run: |
+        cd Example/VoticeDemo
+        
+        # Try with iPhone 15 first
+        if xcodebuild -project VoticeDemo.xcodeproj \
+                      -scheme VoticeDemo \
+                      -destination 'platform=iOS Simulator,name=iPhone 15' \
+                      build \
+                      CODE_SIGN_IDENTITY="" \
+                      CODE_SIGNING_REQUIRED=NO; then
+          echo "Build successful with iPhone 15"
+        # Fallback to iPhone 14 if iPhone 15 is not available
+        elif xcodebuild -project VoticeDemo.xcodeproj \
+                        -scheme VoticeDemo \
+                        -destination 'platform=iOS Simulator,name=iPhone 14' \
+                        build \
+                        CODE_SIGN_IDENTITY="" \
+                        CODE_SIGNING_REQUIRED=NO; then
+          echo "Build successful with iPhone 14"
+        # Final fallback to any iOS simulator
+        else
+          echo "Trying with any available iOS simulator..."
+          xcodebuild -project VoticeDemo.xcodeproj \
+                     -scheme VoticeDemo \
+                     -destination 'generic/platform=iOS Simulator' \
+                     build \
+                     CODE_SIGN_IDENTITY="" \
+                     CODE_SIGNING_REQUIRED=NO
+        fi
 
   release:
     name: Create Tag and Release
@@ -40,40 +74,100 @@ jobs:
     - name: Get latest tag and commit message
       id: get_tag
       run: |
+        # Get the latest tag
         LATEST_TAG=$(git tag --sort=-version:refname | head -n1)
+        echo "Latest tag found: $LATEST_TAG"
         echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 
+        # Calculate new tag
         if [[ $LATEST_TAG =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
           MAJOR=${BASH_REMATCH[1]}
           MINOR=${BASH_REMATCH[2]}
           PATCH=${BASH_REMATCH[3]}
           NEW_PATCH=$((PATCH + 1))
           NEW_TAG="$MAJOR.$MINOR.$NEW_PATCH"
+          echo "Incrementing patch version: $LATEST_TAG -> $NEW_TAG"
+        elif [[ -z "$LATEST_TAG" ]]; then
+          NEW_TAG="1.0.0"
+          echo "No previous tags found, starting with: $NEW_TAG"
         else
-          NEW_TAG="1.0.5"
+          echo "Invalid tag format: $LATEST_TAG"
+          echo "Expected format: X.Y.Z (semantic versioning)"
+          exit 1
         fi
 
         echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
         echo "New tag will be: $NEW_TAG"
 
-        # Get the latest commit message
+        # Get the latest commit message and changelog
         COMMIT_MESSAGE=$(git log -1 --pretty=%B)
         echo "commit_message<<EOF" >> $GITHUB_OUTPUT
         echo "$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
+        
+        # Get changelog since last tag
+        if [[ -n "$LATEST_TAG" ]]; then
+          CHANGELOG=$(git log --pretty=format:"- %s" $LATEST_TAG..HEAD)
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        else
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "- Initial release" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        fi
 
     - name: Create Git tag
       run: |
+        NEW_TAG="${{ steps.get_tag.outputs.new_tag }}"
+        
+        # Check if tag already exists
+        if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+          echo "Tag $NEW_TAG already exists!"
+          exit 1
+        fi
+        
+        # Configure git and create tag
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag ${{ steps.get_tag.outputs.new_tag }}
-        git push origin ${{ steps.get_tag.outputs.new_tag }}
+        
+        echo "Creating tag: $NEW_TAG"
+        git tag "$NEW_TAG"
+        git push origin "$NEW_TAG"
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ steps.get_tag.outputs.new_tag }}
         name: "Votice SDK v${{ steps.get_tag.outputs.new_tag }}"
-        body: "${{ steps.get_tag.outputs.commit_message }}"
+        body: |
+          ## 🚀 Votice SDK v${{ steps.get_tag.outputs.new_tag }}
+          
+          ### Changes in this release:
+          ${{ steps.get_tag.outputs.changelog }}
+          
+          ### Latest commit:
+          ${{ steps.get_tag.outputs.commit_message }}
+          
+          ### Installation
+          
+          #### Swift Package Manager
+          Add this to your `Package.swift`:
+          
+          ```swift
+          dependencies: [
+              .package(url: "https://github.com/ArtCC/votice-sdk.git", from: "${{ steps.get_tag.outputs.new_tag }}")
+          ]
+          ```
+          
+          Or add it through Xcode:
+          1. File → Add Package Dependencies
+          2. Enter: `https://github.com/ArtCC/votice-sdk.git`
+          3. Select version: `${{ steps.get_tag.outputs.new_tag }}`
+          
+          ---
+          *This release was automatically generated from commit ${{ github.sha }}*
+        draft: false
+        prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         cd Example/VoticeDemo
         xcodebuild -project VoticeDemo.xcodeproj \
                    -scheme VoticeDemo \
-                   -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+                   -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' \
                    build \
                    CODE_SIGN_IDENTITY="" \
                    CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         cd Example/VoticeDemo
         xcodebuild -project VoticeDemo.xcodeproj \
                    -scheme VoticeDemo \
-                   -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+                   -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' \
                    build \
                    CODE_SIGN_IDENTITY="" \
                    CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,16 @@ jobs:
     - name: Select Xcode Version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.2'
+        xcode-version: 'latest-stable'
 
     - name: List available simulators
-      run: xcrun simctl list devices --json | jq '.devices | to_entries[] | select(.key | contains("iOS")) | .key'
+      run: |
+        echo "=== Xcode version ==="
+        xcodebuild -version
+        echo "=== Available iOS Simulators ==="
+        xcrun simctl list devices ios
+        echo "=== Available destinations ==="
+        xcodebuild -project Example/VoticeDemo/VoticeDemo.xcodeproj -scheme VoticeDemo -showdestinations
 
     - name: Build and Test Swift Package
       run: swift test --verbose
@@ -29,30 +35,9 @@ jobs:
     - name: Build iOS Example
       run: |
         cd Example/VoticeDemo
-        
-        # Try with iPhone 15 first
-        if xcodebuild -project VoticeDemo.xcodeproj \
-                      -scheme VoticeDemo \
-                      -destination 'platform=iOS Simulator,name=iPhone 15' \
-                      build \
-                      CODE_SIGN_IDENTITY="" \
-                      CODE_SIGNING_REQUIRED=NO; then
-          echo "Build successful with iPhone 15"
-        # Fallback to iPhone 14 if iPhone 15 is not available
-        elif xcodebuild -project VoticeDemo.xcodeproj \
-                        -scheme VoticeDemo \
-                        -destination 'platform=iOS Simulator,name=iPhone 14' \
-                        build \
-                        CODE_SIGN_IDENTITY="" \
-                        CODE_SIGNING_REQUIRED=NO; then
-          echo "Build successful with iPhone 14"
-        # Final fallback to any iOS simulator
-        else
-          echo "Trying with any available iOS simulator..."
-          xcodebuild -project VoticeDemo.xcodeproj \
-                     -scheme VoticeDemo \
-                     -destination 'generic/platform=iOS Simulator' \
-                     build \
-                     CODE_SIGN_IDENTITY="" \
-                     CODE_SIGNING_REQUIRED=NO
-        fi
+        xcodebuild -project VoticeDemo.xcodeproj \
+                   -scheme VoticeDemo \
+                   -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+                   build \
+                   CODE_SIGN_IDENTITY="" \
+                   CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Select Xcode Version
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.2'
+
+    - name: List available simulators
+      run: xcrun simctl list devices --json | jq '.devices | to_entries[] | select(.key | contains("iOS")) | .key'
 
     - name: Build and Test Swift Package
       run: swift test --verbose
@@ -24,9 +29,30 @@ jobs:
     - name: Build iOS Example
       run: |
         cd Example/VoticeDemo
-        xcodebuild -project VoticeDemo.xcodeproj \
-                   -scheme VoticeDemo \
-                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
-                   build \
-                   CODE_SIGN_IDENTITY="" \
-                   CODE_SIGNING_REQUIRED=NO
+        
+        # Try with iPhone 15 first
+        if xcodebuild -project VoticeDemo.xcodeproj \
+                      -scheme VoticeDemo \
+                      -destination 'platform=iOS Simulator,name=iPhone 15' \
+                      build \
+                      CODE_SIGN_IDENTITY="" \
+                      CODE_SIGNING_REQUIRED=NO; then
+          echo "Build successful with iPhone 15"
+        # Fallback to iPhone 14 if iPhone 15 is not available
+        elif xcodebuild -project VoticeDemo.xcodeproj \
+                        -scheme VoticeDemo \
+                        -destination 'platform=iOS Simulator,name=iPhone 14' \
+                        build \
+                        CODE_SIGN_IDENTITY="" \
+                        CODE_SIGNING_REQUIRED=NO; then
+          echo "Build successful with iPhone 14"
+        # Final fallback to any iOS simulator
+        else
+          echo "Trying with any available iOS simulator..."
+          xcodebuild -project VoticeDemo.xcodeproj \
+                     -scheme VoticeDemo \
+                     -destination 'generic/platform=iOS Simulator' \
+                     build \
+                     CODE_SIGN_IDENTITY="" \
+                     CODE_SIGNING_REQUIRED=NO
+        fi

--- a/Example/VoticeDemo/VoticeDemo.xcodeproj/project.pbxproj
+++ b/Example/VoticeDemo/VoticeDemo.xcodeproj/project.pbxproj
@@ -653,12 +653,12 @@
 			projectRoot = "";
 			targets = (
 				802F7E5F2E0F198400F1BDF6 /* VoticeDemo */,
+				800727272E11A9FC00C43BA8 /* VoticeDemo_macOS */,
+				800727662E11ACD400C43BA8 /* VoticeDemo_tvOS */,
 				802F7E6C2E0F198500F1BDF6 /* VoticeDemoTests */,
 				802F7E762E0F198500F1BDF6 /* VoticeDemoUITests */,
-				800727272E11A9FC00C43BA8 /* VoticeDemo_macOS */,
 				800727342E11A9FE00C43BA8 /* VoticeDemo_macOSTests */,
 				8007273E2E11A9FE00C43BA8 /* VoticeDemo_macOSUITests */,
-				800727662E11ACD400C43BA8 /* VoticeDemo_tvOS */,
 				800727722E11ACD600C43BA8 /* VoticeDemo_tvOSTests */,
 				8007277C2E11ACD600C43BA8 /* VoticeDemo_tvOSUITests */,
 			);

--- a/Example/VoticeDemo/VoticeDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/VoticeDemo/VoticeDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "977d1abd34c8717fcd20af1a07cb2a5451d64463707476988f0c37a311eff864",
+  "originHash" : "733df6d8285157f80e50eecdc876c02ccc409d5ac4447868dc1270597958eea2",
   "pins" : [
     {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "8545ddf4de043e6f2051c5cf204f39ef778ebf6b",
-        "version" : "0.59.1"
+        "revision" : "6166499ede0efe43c3809f101d2c3cd409e2b77a",
+        "version" : "0.61.0"
       }
     }
   ],

--- a/Example/VoticeDemo/VoticeDemo/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo/HomeView.swift
@@ -128,6 +128,7 @@ private extension HomeView {
             Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
             Votice.setShowCompletedSeparately(enabled: true)
+            Votice.setVisibleOptionalStatuses(accepted: true, blocked: false, rejected: false)
 
             isConfigured = Votice.isConfigured
 

--- a/Example/VoticeDemo/VoticeDemo/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo/HomeView.swift
@@ -127,6 +127,7 @@ private extension HomeView {
             Votice.setFonts(poppinsConfig)
             Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
+            Votice.setShowCompletedSeparately(enabled: true)
 
             isConfigured = Votice.isConfigured
 

--- a/Example/VoticeDemo/VoticeDemo/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo/HomeView.swift
@@ -125,7 +125,7 @@ private extension HomeView {
                 ]
             )
             Votice.setFonts(poppinsConfig)
-            Votice.setDebugLogging(enabled: false)
+            Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
 
             isConfigured = Votice.isConfigured

--- a/Example/VoticeDemo/VoticeDemo/Shared/SpanishTexts.swift
+++ b/Example/VoticeDemo/VoticeDemo/Shared/SpanishTexts.swift
@@ -32,6 +32,8 @@ struct SpanishTexts: VoticeTextsProtocol {
     let beFirstToSuggest = "¡Sé el primero en sugerir algo!"
     let featureRequests = "Sugerencias"
     let all = "Todas"
+    let activeTab = "Activas"
+    let completedTab = "Completadas"
     let pending = "Pendiente"
     let accepted = "Aceptada"
     let blocked = "Bloqueada"

--- a/Example/VoticeDemo/VoticeDemo_macOS/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo_macOS/HomeView.swift
@@ -71,7 +71,7 @@ private extension HomeView {
                 ]
             )
             Votice.setFonts(poppinsConfig)
-            Votice.setDebugLogging(enabled: false)
+            Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
 
             isConfigured = Votice.isConfigured

--- a/Example/VoticeDemo/VoticeDemo_macOS/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo_macOS/HomeView.swift
@@ -74,6 +74,7 @@ private extension HomeView {
             Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
             Votice.setShowCompletedSeparately(enabled: true)
+            Votice.setVisibleOptionalStatuses(accepted: true, blocked: false, rejected: false)
 
             isConfigured = Votice.isConfigured
 

--- a/Example/VoticeDemo/VoticeDemo_macOS/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo_macOS/HomeView.swift
@@ -73,6 +73,7 @@ private extension HomeView {
             Votice.setFonts(poppinsConfig)
             Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
+            Votice.setShowCompletedSeparately(enabled: true)
 
             isConfigured = Votice.isConfigured
 

--- a/Example/VoticeDemo/VoticeDemo_tvOS/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo_tvOS/HomeView.swift
@@ -75,6 +75,7 @@ private extension HomeView {
             Votice.setFonts(poppinsConfig)
             Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
+            Votice.setShowCompletedSeparately(enabled: false)
 
             isConfigured = Votice.isConfigured
 

--- a/Example/VoticeDemo/VoticeDemo_tvOS/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo_tvOS/HomeView.swift
@@ -76,6 +76,7 @@ private extension HomeView {
             Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
             Votice.setShowCompletedSeparately(enabled: false)
+            Votice.setVisibleOptionalStatuses(accepted: true, blocked: true, rejected: true)
 
             isConfigured = Votice.isConfigured
 

--- a/Example/VoticeDemo/VoticeDemo_tvOS/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo_tvOS/HomeView.swift
@@ -73,7 +73,7 @@ private extension HomeView {
                 ]
             )
             Votice.setFonts(poppinsConfig)
-            Votice.setDebugLogging(enabled: false)
+            Votice.setDebugLogging(enabled: true)
             Votice.setCommentIsEnabled(enabled: true)
 
             isConfigured = Votice.isConfigured

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Votice management app for handling suggestions and apps is available for dow
 Add this line to your `Package.swift` dependencies:
 
 ```swift
-.package(url: "https://github.com/artcc/votice-sdk", from: "1.0.7"),
+.package(url: "https://github.com/artcc/votice-sdk", from: "1.0.8"),
 ```
 
 Or via Xcode:

--- a/README.md
+++ b/README.md
@@ -315,6 +315,38 @@ Disable (returns to original behavior):
 Votice.setShowCompletedSeparately(enabled: false)
 ```
 
+### 9. Configure visible suggestion statuses (Optional)
+
+By default, all optional statuses (`accepted`, `blocked`, `rejected`) are visible along with the mandatory ones. You can choose which optional statuses to show in both the list and the filter menu.
+
+Mandatory statuses (always shown):
+- `completed` (or in its separate tab if you enabled section 8)
+- `in-progress`
+- `pending`
+
+Optional statuses (individually hideable):
+- `accepted`
+- `blocked`
+- `rejected`
+
+Configure which optional statuses are visible:
+```swift
+// Example: show accepted & rejected, hide blocked
+Votice.setVisibleOptionalStatuses(accepted: true, blocked: false, rejected: true)
+```
+
+Behavior:
+- Hidden optional statuses are removed from the filter menu and never displayed in the list.
+- If a previously selected (persisted) filter becomes hidden, it is automatically cleared.
+- Works together with the "completed separately" mode (section 8). If that mode is active, `completed` will still not appear in filters, regardless of this configuration.
+- Defaults: all three optional statuses visible (equivalent to `true, true, true`).
+
+Use cases:
+- Simplify the board for early product phases (e.g. only pending + in-progress + completed)
+- Gradually introduce refinement states later (enable accepted / blocked / rejected)
+
+> Note: Calling this method multiple times replaces the previous configuration entirely.
+
 ---
 
 ## 👨🏻‍💻 Contributing to Votice SDK

--- a/README.md
+++ b/README.md
@@ -296,6 +296,27 @@ Votice.setDebugLogging(enabled: false)
 
 **Note:** Debug logging is automatically disabled in production builds and should only be enabled when specifically needed for debugging purposes.
 
+### 8. Show completed suggestions in a separate tab (Optional)
+
+You can choose to display suggestions with status `completed` in their own tab. When enabled:
+
+- A segmented control appears with two tabs: "Active" and "Completed".
+- Completed suggestions are removed from the main list.
+- The "Completed" filter disappears from the filter menu (no longer needed).
+- Completed suggestions are only visible in the dedicated tab.
+- If you don't enable it, the behavior remains the same as before.
+
+Enable:
+```swift
+Votice.setShowCompletedSeparately(enabled: true)
+```
+Disable (returns to original behavior):
+```swift
+Votice.setShowCompletedSeparately(enabled: false)
+```
+
+---
+
 ## 👨🏻‍💻 Contributing to Votice SDK
 
 Thank you for your interest in contributing to **Votice**!  

--- a/Sources/Votice/Core/Managers/ConfigurationManager.swift
+++ b/Sources/Votice/Core/Managers/ConfigurationManager.swift
@@ -17,6 +17,7 @@ protocol ConfigurationManagerProtocol: Sendable {
     var apiSecret: String { get }
     var appId: String { get }
     var commentIsEnabled: Bool { get set }
+    var showCompletedSeparately: Bool { get set }
     var version: String { get }
     var buildNumber: String { get }
 
@@ -37,6 +38,7 @@ final class ConfigurationManager: ConfigurationManagerProtocol, @unchecked Senda
     private var _appId = ""
     private var _isConfigured = false
     private var _commentIsEnabled = true
+    private var _showCompletedSeparately = false
 
     private let lock = NSLock()
     private let _baseURL = "https://api.votice.app/api"
@@ -76,6 +78,15 @@ final class ConfigurationManager: ConfigurationManagerProtocol, @unchecked Senda
         }
         set {
             lock.withLock { _commentIsEnabled = newValue }
+        }
+    }
+
+    var showCompletedSeparately: Bool {
+        get {
+            lock.withLock { _showCompletedSeparately }
+        }
+        set {
+            lock.withLock { _showCompletedSeparately = newValue }
         }
     }
 
@@ -138,6 +149,7 @@ final class ConfigurationManager: ConfigurationManagerProtocol, @unchecked Senda
             _appId = ""
             _isConfigured = false
             _commentIsEnabled = true
+            _showCompletedSeparately = false
 
             LogManager.shared.devLog(.info, "ConfigurationManager: reset")
         }

--- a/Sources/Votice/Core/Managers/ConfigurationManager.swift
+++ b/Sources/Votice/Core/Managers/ConfigurationManager.swift
@@ -41,7 +41,7 @@ final class ConfigurationManager: ConfigurationManagerProtocol, @unchecked Senda
     private let lock = NSLock()
     private let _baseURL = "https://api.votice.app/api"
     private let _configurationId = UUID().uuidString
-    private let _version = "1.0.7"
+    private let _version = "1.0.8"
     private let _buildNumber = "1"
 
     // MARK: - Public properties

--- a/Sources/Votice/Core/Managers/StorageManager.swift
+++ b/Sources/Votice/Core/Managers/StorageManager.swift
@@ -1,0 +1,48 @@
+//
+//  StorageManager.swift
+//  Votice
+//
+//  Created by Arturo Carretero Calvo on 7/9/25.
+//  Copyright © 2025 ArtCC. All rights reserved.
+//
+
+import Foundation
+
+protocol StorageManagerProtocol {
+    func save<T: Codable>(_ object: T, forKey key: String) throws
+    func load<T: Codable>(forKey key: String, as type: T.Type) throws -> T?
+    func delete(forKey key: String) throws
+}
+
+final class StorageManager: StorageManagerProtocol {
+    // MARK: - Properties
+
+    private let userDefaults: UserDefaults
+
+    // MARK: - Init
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    // MARK: - Functions
+
+    func save<T: Codable>(_ object: T, forKey key: String) throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(object)
+
+        userDefaults.set(data, forKey: key)
+    }
+
+    func load<T: Codable>(forKey key: String, as type: T.Type) throws -> T? {
+        guard let data = userDefaults.data(forKey: key) else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    func delete(forKey key: String) throws {
+        userDefaults.removeObject(forKey: key)
+    }
+}

--- a/Sources/Votice/Core/Managers/TextManager.swift
+++ b/Sources/Votice/Core/Managers/TextManager.swift
@@ -33,6 +33,8 @@ public protocol VoticeTextsProtocol: Sendable {
     var beFirstToSuggest: String { get }
     var featureRequests: String { get }
     var all: String { get }
+    var activeTab: String { get }
+    var completedTab: String { get }
     var pending: String { get }
     var accepted: String { get }
     var blocked: String { get }
@@ -109,6 +111,8 @@ public struct DefaultVoticeTexts: VoticeTextsProtocol {
     public let beFirstToSuggest = "Be the first to suggest something!"
     public let featureRequests = "Feature Requests"
     public let all = "All"
+    public let activeTab = "Active"
+    public let completedTab = "Completed"
     public let pending = "Pending"
     public let accepted = "Accepted"
     public let blocked = "Blocked"

--- a/Sources/Votice/Core/Models/StorageKey.swift
+++ b/Sources/Votice/Core/Models/StorageKey.swift
@@ -1,0 +1,13 @@
+//
+//  StorageKey.swift
+//  Votice
+//
+//  Created by Arturo Carretero Calvo on 7/9/25.
+//  Copyright © 2025 ArtCC. All rights reserved.
+//
+
+import Foundation
+
+enum StorageKey: String {
+    case filterApplied
+}

--- a/Sources/Votice/UI/Components/CustomSegmentedControl.swift
+++ b/Sources/Votice/UI/Components/CustomSegmentedControl.swift
@@ -1,0 +1,90 @@
+//
+//  CustomSegmentedControl.swift
+//  Votice
+//
+//  Created by Arturo Carretero Calvo on 7/9/25.
+//  Copyright © 2025 ArtCC. All rights reserved.
+//
+
+import SwiftUI
+
+struct CustomSegmentedControl: View {
+    // MARK: - Types
+
+    struct Segment: Identifiable, Hashable {
+        let id: Int
+        let title: String
+    }
+
+    // MARK: - Properties
+
+    @Environment(\.voticeTheme) private var theme
+
+    @Binding var selection: Int
+
+    private var controlHeight: CGFloat {
+#if os(tvOS)
+        50
+#else
+        35
+#endif
+    }
+
+    private let segmentSpacing: CGFloat = 5
+    private let innerVerticalPadding: CGFloat = 5
+    private let innerHorizontalPadding: CGFloat = 5
+
+    let segments: [Segment]
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: segmentSpacing) {
+            ForEach(segments) { segment in
+                let isSelected = segment.id == selection
+
+                Button {
+                    guard !isSelected else {
+                        return
+                    }
+
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        selection = segment.id
+                    }
+                } label: {
+                    Text(segment.title)
+                        .font(theme.typography.callout)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                        .foregroundColor(isSelected ? .white : theme.colors.onBackground)
+                        .padding(.vertical, innerVerticalPadding)
+                        .padding(.horizontal, innerHorizontalPadding)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(
+                            RoundedRectangle(cornerRadius: theme.cornerRadius.sm)
+                                .fill(isSelected ? theme.colors.primary : Color.clear)
+                        )
+                        .contentShape(Rectangle())
+                }
+#if os(iOS) || os(macOS)
+                .buttonStyle(.plain)
+#else
+                .buttonStyle(.card)
+#endif
+            }
+        }
+        .frame(height: controlHeight)
+        .background(
+            RoundedRectangle(cornerRadius: theme.cornerRadius.sm)
+                .fill(theme.colors.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: theme.cornerRadius.sm)
+                        .stroke(theme.colors.primary.opacity(0.1), lineWidth: 1)
+                )
+                .shadow(color: theme.colors.primary.opacity(0.05), radius: 2, x: 0, y: 1)
+        )
+        .padding(.top, theme.spacing.md)
+        .padding(.horizontal, theme.spacing.md)
+        .padding(.bottom, theme.spacing.xs)
+    }
+}

--- a/Sources/Votice/UI/Components/FilterMenuView.swift
+++ b/Sources/Votice/UI/Components/FilterMenuView.swift
@@ -15,6 +15,10 @@ struct FilterMenuView: View {
 
     @Binding var isExpanded: Bool
 
+    private var showCompletedSeparately: Bool {
+        ConfigurationManager.shared.showCompletedSeparately
+    }
+
     let selectedFilter: SuggestionStatusEntity?
     let onFilterSelected: (SuggestionStatusEntity?) -> Void
 
@@ -85,9 +89,11 @@ private extension FilterMenuView {
             Divider()
                 .background(theme.colors.secondary.opacity(0.05))
             filterOption(title: TextManager.shared.texts.blocked, filter: .blocked)
-            Divider()
-                .background(theme.colors.secondary.opacity(0.05))
-            filterOption(title: TextManager.shared.texts.completed, filter: .completed)
+            if !showCompletedSeparately {
+                Divider()
+                    .background(theme.colors.secondary.opacity(0.05))
+                filterOption(title: TextManager.shared.texts.completed, filter: .completed)
+            }
             Divider()
                 .background(theme.colors.secondary.opacity(0.05))
             filterOption(title: TextManager.shared.texts.inProgress, filter: .inProgress)

--- a/Sources/Votice/UI/Components/FilterMenuView.swift
+++ b/Sources/Votice/UI/Components/FilterMenuView.swift
@@ -18,6 +18,37 @@ struct FilterMenuView: View {
     private var showCompletedSeparately: Bool {
         ConfigurationManager.shared.showCompletedSeparately
     }
+    private var optionalVisible: Set<SuggestionStatusEntity> {
+        ConfigurationManager.shared.optionalVisibleStatuses
+    }
+    private var orderedVisibleStatuses: [SuggestionStatusEntity] {
+        // Mandatory always (except completed if separated)
+        var result: [SuggestionStatusEntity] = []
+
+        // Optional insertion order: accepted, blocked, rejected if present
+        let optionalOrder: [SuggestionStatusEntity] = [.accepted, .blocked, .rejected]
+
+        // Append optional in defined order if present
+        for status in optionalOrder where optionalVisible.contains(status) {
+            result.append(status)
+        }
+
+        // Always append completed if not separated
+        if !showCompletedSeparately {
+            result.append(.completed)
+        }
+
+        // Always append in-progress and pending
+        result.append(.inProgress)
+        result.append(.pending)
+
+        // Safety check: ensure blocked and rejected are included if in optionalVisible
+        if optionalVisible.contains(.rejected) && !result.contains(.rejected) {
+            result.append(.rejected)
+        }
+
+        return result
+    }
 
     let selectedFilter: SuggestionStatusEntity?
     let onFilterSelected: (SuggestionStatusEntity?) -> Void
@@ -50,6 +81,8 @@ struct FilterMenuView: View {
 // MARK: - Private
 
 private extension FilterMenuView {
+    // MARK: - Properties
+
     var filterButton: some View {
         Button {
             withAnimation(.easeInOut(duration: 0.2)) {
@@ -83,26 +116,11 @@ private extension FilterMenuView {
     var filterDropdown: some View {
         VStack(alignment: .leading, spacing: 0) {
             filterOption(title: TextManager.shared.texts.all, filter: nil)
-            Divider()
-                .background(theme.colors.secondary.opacity(0.05))
-            filterOption(title: TextManager.shared.texts.accepted, filter: .accepted)
-            Divider()
-                .background(theme.colors.secondary.opacity(0.05))
-            filterOption(title: TextManager.shared.texts.blocked, filter: .blocked)
-            if !showCompletedSeparately {
-                Divider()
-                    .background(theme.colors.secondary.opacity(0.05))
-                filterOption(title: TextManager.shared.texts.completed, filter: .completed)
+            ForEach(Array(orderedVisibleStatuses.enumerated()), id: \.element) { _, status in
+                Divider().background(theme.colors.secondary.opacity(0.05))
+
+                filterOption(title: title(for: status), filter: status)
             }
-            Divider()
-                .background(theme.colors.secondary.opacity(0.05))
-            filterOption(title: TextManager.shared.texts.inProgress, filter: .inProgress)
-            Divider()
-                .background(theme.colors.secondary.opacity(0.05))
-            filterOption(title: TextManager.shared.texts.pending, filter: .pending)
-            Divider()
-                .background(theme.colors.secondary.opacity(0.05))
-            filterOption(title: TextManager.shared.texts.rejected, filter: .rejected)
         }
 #if os(iOS) || os(macOS)
         .background(
@@ -119,7 +137,19 @@ private extension FilterMenuView {
 #endif
     }
 
-    // swiftlint:disable function_body_length
+    // MARK: - Functions
+
+    func title(for status: SuggestionStatusEntity) -> String {
+        switch status {
+        case .accepted: return TextManager.shared.texts.accepted
+        case .blocked: return TextManager.shared.texts.blocked
+        case .completed: return TextManager.shared.texts.completed
+        case .inProgress: return TextManager.shared.texts.inProgress
+        case .pending: return TextManager.shared.texts.pending
+        case .rejected: return TextManager.shared.texts.rejected
+        }
+    }
+
     func filterOption(title: String, filter: SuggestionStatusEntity?) -> some View {
         Button {
             onFilterSelected(filter)
@@ -142,37 +172,12 @@ private extension FilterMenuView {
             .padding(.horizontal, theme.spacing.md)
             .padding(.vertical, theme.spacing.sm)
             .contentShape(Rectangle())
+            .background(selectedFilter == filter ? theme.colors.primary.opacity(0.1) : Color.clear)
         }
 #if os(iOS) || os(macOS)
         .buttonStyle(.plain)
 #elseif os(tvOS)
         .buttonStyle(.card)
 #endif
-        .background(
-            Group {
-                if selectedFilter == filter {
-                    if filter == nil {
-                        UnevenRoundedRectangle(
-                            topLeadingRadius: theme.cornerRadius.md,
-                            topTrailingRadius: theme.cornerRadius.md
-                        )
-                        .fill(theme.colors.primary.opacity(0.1))
-                    } else if filter == .completed {
-                        UnevenRoundedRectangle(
-                            bottomLeadingRadius: theme.cornerRadius.md,
-                            bottomTrailingRadius: theme.cornerRadius.md
-                        )
-                        .fill(theme.colors.primary.opacity(0.1))
-                    } else {
-                        Rectangle()
-                            .fill(theme.colors.primary.opacity(0.1))
-                    }
-                } else {
-                    Rectangle()
-                        .fill(Color.clear)
-                }
-            }
-        )
     }
-    // swiftlint:enable function_body_length
 }

--- a/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionView.swift
+++ b/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionView.swift
@@ -124,7 +124,7 @@ private extension CreateSuggestionView {
         .padding(theme.spacing.md)
         .background(
             theme.colors.background
-                .shadow(color: theme.colors.primary.opacity(0.1), radius: 2, x: 0, y: 1)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
         )
     }
 

--- a/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailView.swift
+++ b/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailView.swift
@@ -132,7 +132,7 @@ private extension SuggestionDetailView {
         .padding(theme.spacing.md)
         .background(
             theme.colors.background
-                .shadow(color: theme.colors.primary.opacity(0.1), radius: 2, x: 0, y: 1)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
         )
     }
 
@@ -448,7 +448,7 @@ private extension SuggestionDetailView {
         .padding(theme.spacing.md)
         .background(
             theme.colors.background
-                .shadow(color: theme.colors.primary.opacity(0.1), radius: 2, x: 0, y: 1)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
         )
     }
 

--- a/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailViewModel.swift
+++ b/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailViewModel.swift
@@ -27,9 +27,9 @@ final class SuggestionDetailViewModel: ObservableObject {
 
     private var lastLoadedCreatedAt: String?
 
+    private let pageSize = 10
     private let commentUseCase: CommentUseCaseProtocol
     private let suggestionUseCase: SuggestionUseCaseProtocol
-    private let pageSize = 10
 
     var isCommentFormValid: Bool {
         !newComment.isEmpty

--- a/Sources/Votice/UI/Views/SuggestionList/SuggestionListView.swift
+++ b/Sources/Votice/UI/Views/SuggestionList/SuggestionListView.swift
@@ -116,7 +116,7 @@ private extension SuggestionListView {
         .padding(theme.spacing.md)
         .background(
             theme.colors.background
-                .shadow(color: theme.colors.primary.opacity(0.1), radius: 2, x: 0, y: 1)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
         )
         .zIndex(1)
     }
@@ -209,7 +209,7 @@ private extension SuggestionListView {
         .padding(theme.spacing.md)
         .background(
             theme.colors.background
-                .shadow(color: theme.colors.primary.opacity(0.1), radius: 2, x: 0, y: 1)
+                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
         )
         .onChange(of: viewModel.selectedTab) { newValue in
             viewModel.selectTab(newValue)

--- a/Sources/Votice/UI/Views/SuggestionList/SuggestionListView.swift
+++ b/Sources/Votice/UI/Views/SuggestionList/SuggestionListView.swift
@@ -201,18 +201,13 @@ private extension SuggestionListView {
     }
 
     var segmentedControl: some View {
-        Picker("", selection: $viewModel.selectedTab) {
-            Text(TextManager.shared.texts.activeTab).tag(0)
-            Text(TextManager.shared.texts.completedTab).tag(1)
-        }
-        .pickerStyle(SegmentedPickerStyle())
-        .padding(theme.spacing.md)
-        .background(
-            theme.colors.background
-                .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+        CustomSegmentedControl(
+            selection: $viewModel.selectedTab,
+            segments: [
+                .init(id: 0, title: TextManager.shared.texts.activeTab),
+                .init(id: 1, title: TextManager.shared.texts.completedTab)
+            ]
         )
-        .onChange(of: viewModel.selectedTab) { newValue in
-            viewModel.selectTab(newValue)
-        }
+        .transition(.opacity.combined(with: .move(edge: .top)))
     }
 }

--- a/Sources/Votice/Votice.swift
+++ b/Sources/Votice/Votice.swift
@@ -118,9 +118,11 @@ public struct Votice {
     ///   - primaryColor: Primary color for buttons and accents
     ///   - backgroundColor: Background color for the interface
     ///   - surfaceColor: Surface color for cards and components
-    public static func createTheme(primaryColor: Color? = nil,
-                                   backgroundColor: Color? = nil,
-                                   surfaceColor: Color? = nil) -> VoticeTheme {
+    public static func createTheme(
+        primaryColor: Color? = nil,
+        backgroundColor: Color? = nil,
+        surfaceColor: Color? = nil
+    ) -> VoticeTheme {
         // Use smart defaults if no colors are provided
         createAdvancedTheme(primaryColor: primaryColor,
                             backgroundColor: backgroundColor,
@@ -296,9 +298,11 @@ public struct Votice {
     ///   - backgroundColor: Background color for the interface
     ///   - surfaceColor: Surface color for cards and components
     /// - Returns: A theme with current font configuration applied
-    public static func createThemeWithCurrentFonts(primaryColor: Color? = nil,
-                                                   backgroundColor: Color? = nil,
-                                                   surfaceColor: Color? = nil) -> VoticeTheme {
+    public static func createThemeWithCurrentFonts(
+        primaryColor: Color? = nil,
+        backgroundColor: Color? = nil,
+        surfaceColor: Color? = nil
+    ) -> VoticeTheme {
         let colors = createAdvancedTheme(
             primaryColor: primaryColor,
             backgroundColor: backgroundColor,

--- a/Sources/Votice/Votice.swift
+++ b/Sources/Votice/Votice.swift
@@ -69,6 +69,13 @@ public struct Votice {
         ConfigurationManager.shared.showCompletedSeparately = enabled
     }
 
+    /// Configure optional visible statuses for suggestions
+    /// - Parameter statuses: Array of `SuggestionStatusEntity` representing the statuses to be visible
+    /// - Note: This can be used to customize which suggestion statuses are shown in the UI
+    public static func setVisibleOptionalStatuses(accepted: Bool, blocked: Bool, rejected: Bool) {
+        ConfigurationManager.shared.setOptionalVisibleStatus(accepted: accepted, blocked: blocked, rejected: rejected)
+    }
+
     // MARK: - UI Presentation
 
     /// Present the Votice feedback interface
@@ -124,9 +131,11 @@ public struct Votice {
         surfaceColor: Color? = nil
     ) -> VoticeTheme {
         // Use smart defaults if no colors are provided
-        createAdvancedTheme(primaryColor: primaryColor,
-                            backgroundColor: backgroundColor,
-                            surfaceColor: surfaceColor)
+        createAdvancedTheme(
+            primaryColor: primaryColor,
+            backgroundColor: backgroundColor,
+            surfaceColor: surfaceColor
+        )
     }
 
     /// Get a system theme that automatically adapts to the user's appearance preference

--- a/Sources/Votice/Votice.swift
+++ b/Sources/Votice/Votice.swift
@@ -61,6 +61,14 @@ public struct Votice {
         ConfigurationManager.shared.commentIsEnabled = enabled
     }
 
+    /// Enable or disable showing completed suggestions separately with a segmented control
+    /// - Parameter enabled: Whether to show completed suggestions in a separate tab
+    /// - Note: When enabled, completed suggestions will be shown in a dedicated tab and removed from the main
+    /// list and filter options. Disabled by default.
+    public static func setShowCompletedSeparately(enabled: Bool) {
+        ConfigurationManager.shared.showCompletedSeparately = enabled
+    }
+
     // MARK: - UI Presentation
 
     /// Present the Votice feedback interface

--- a/Tests/VoticeTests/Managers/TextManagerTests.swift
+++ b/Tests/VoticeTests/Managers/TextManagerTests.swift
@@ -15,72 +15,74 @@ import Foundation
 struct MockVoticeTexts: VoticeTextsProtocol {
     // MARK: - General
 
-    let cancel = "Cancelar"
-    let error = "Error"
-    let ok = "Aceptar"
-    let submit = "Enviar"
-    let optional = "Opcional"
-    let success = "Éxito"
-    let warning = "Advertencia"
-    let info = "Información"
-    let genericError = "Algo salió mal. Por favor, inténtalo de nuevo."
-    let anonymous = "Anónimo"
+    let cancel = "Test Cancel"
+    let error = "Test Error"
+    let ok = "Test OK"
+    let submit = "Test Submit"
+    let optional = "Test Optional"
+    let success = "Test Success"
+    let warning = "Test Warning"
+    let info = "Test Info"
+    let genericError = "Test Generic Error"
+    let anonymous = "Test Anonymous"
 
     // MARK: - Suggestion List
 
-    let loadingSuggestions = "Cargando sugerencias..."
-    let noSuggestionsYet = "No hay sugerencias aún."
-    let beFirstToSuggest = "¡Sé el primero en sugerir algo!"
-    let featureRequests = "Solicitudes de funciones"
-    let all = "Todas"
-    let pending = "Pendiente"
-    let accepted = "Aceptada"
-    let blocked = "Bloqueada"
-    let inProgress = "En progreso"
-    let completed = "Completada"
-    let rejected = "Rechazada"
-    let tapPlusToGetStarted = "Toca + para empezar"
-    let loadingMore = "Cargando más..."
+    let loadingSuggestions = "Test Loading"
+    let noSuggestionsYet = "Test No Suggestions"
+    let beFirstToSuggest = "Test Be First"
+    let featureRequests = "Test Feature Requests"
+    let all = "Test All"
+    let activeTab = "Test Active"
+    let completedTab = "Test Completed"
+    let pending = "Test Pending"
+    let accepted = "Test Accepted"
+    let blocked = "Test Blocked"
+    let inProgress = "Test In Progress"
+    let completed = "Test Completed"
+    let rejected = "Test Rejected"
+    let tapPlusToGetStarted = "Test Tap Plus"
+    let loadingMore = "Test Loading More"
 
     // MARK: - Suggestion Detail
 
-    let suggestionTitle = "Sugerencia"
-    let close = "Cerrar"
-    let deleteSuggestionTitle = "Eliminar Sugerencia"
-    let deleteSuggestionMessage = "¿Estás seguro de que quieres eliminar esta sugerencia?"
-    let delete = "Eliminar"
-    let suggestedBy = "Sugerido por"
-    let suggestedAnonymously = "Sugerido anónimamente"
-    let votes = "votos"
-    let comments = "comentarios"
-    let commentsSection = "Comentarios"
-    let loadingComments = "Cargando comentarios..."
-    let noComments = "No hay comentarios aún. ¡Sé el primero en comentar!"
-    let addComment = "Añadir comentario"
-    let yourComment = "Tu Comentario"
-    let shareYourThoughts = "Comparte tus pensamientos..."
-    let yourNameOptional = "Tu Nombre (Opcional)"
-    let enterYourName = "Introduce tu nombre"
-    let newComment = "Nuevo Comentario"
-    let post = "Publicar"
-    let deleteCommentTitle = "Eliminar Comentario"
-    let deleteCommentMessage = "¿Estás seguro de que quieres eliminar este comentario?"
-    let deleteCommentPrimary = "Eliminar"
+    let suggestionTitle = "Test Suggestion"
+    let close = "Test Close"
+    let deleteSuggestionTitle = "Test Delete Suggestion"
+    let deleteSuggestionMessage = "Test Delete Message"
+    let delete = "Test Delete"
+    let suggestedBy = "Test Suggested By"
+    let suggestedAnonymously = "Test Suggested Anonymously"
+    let votes = "test votes"
+    let comments = "test comments"
+    let commentsSection = "Test Comments"
+    let loadingComments = "Test Loading Comments"
+    let noComments = "Test No Comments"
+    let addComment = "Test Add Comment"
+    let yourComment = "Test Your Comment"
+    let shareYourThoughts = "Test Share Thoughts"
+    let yourNameOptional = "Test Your Name"
+    let enterYourName = "Test Enter Name"
+    let newComment = "Test New Comment"
+    let post = "Test Post"
+    let deleteCommentTitle = "Test Delete Comment"
+    let deleteCommentMessage = "Test Delete Comment Message"
+    let deleteCommentPrimary = "Test Delete"
 
     // MARK: - Create Suggestion
 
-    let newSuggestion = "Nueva Sugerencia"
-    let shareYourIdea = "Comparte tu idea"
-    let helpUsImprove = "Ayúdanos a mejorar sugiriendo nuevas funciones o mejoras."
-    let title = "Título"
-    let titlePlaceholder = "Introduce un título breve para tu sugerencia"
-    let keepItShort = "Manténlo corto y descriptivo"
-    let descriptionOptional = "Descripción (Opcional)"
-    let descriptionPlaceholder = "Describe tu sugerencia en detalle..."
-    let explainWhyUseful = "Explica por qué esta función sería útil"
-    let yourNameOptionalCreate = "Tu Nombre (Opcional)"
-    let enterYourNameCreate = "Introduce tu nombre"
-    let leaveEmptyAnonymous = "Déjalo vacío para enviar anónimamente"
+    let newSuggestion = "Test New Suggestion"
+    let shareYourIdea = "Test Share Idea"
+    let helpUsImprove = "Test Help Improve"
+    let title = "Test Title"
+    let titlePlaceholder = "Test Title Placeholder"
+    let keepItShort = "Test Keep Short"
+    let descriptionOptional = "Test Description"
+    let descriptionPlaceholder = "Test Description Placeholder"
+    let explainWhyUseful = "Test Explain Useful"
+    let yourNameOptionalCreate = "Test Your Name Create"
+    let enterYourNameCreate = "Test Enter Name Create"
+    let leaveEmptyAnonymous = "Test Leave Empty"
 }
 
 // MARK: - TextManager Tests
@@ -123,14 +125,14 @@ func testTextManagerUpdateTexts() async {
     let updatedTexts = manager.texts
 
     // Then
-    #expect(updatedTexts.cancel == "Cancelar")
-    #expect(updatedTexts.error == "Error")
-    #expect(updatedTexts.ok == "Aceptar")
-    #expect(updatedTexts.submit == "Enviar")
-    #expect(updatedTexts.optional == "Opcional")
-    #expect(updatedTexts.loadingSuggestions == "Cargando sugerencias...")
-    #expect(updatedTexts.featureRequests == "Solicitudes de funciones")
-    #expect(updatedTexts.newSuggestion == "Nueva Sugerencia")
+    #expect(updatedTexts.cancel == "Test Cancel")
+    #expect(updatedTexts.error == "Test Error")
+    #expect(updatedTexts.ok == "Test OK")
+    #expect(updatedTexts.submit == "Test Submit")
+    #expect(updatedTexts.optional == "Test Optional")
+    #expect(updatedTexts.loadingSuggestions == "Test Loading")
+    #expect(updatedTexts.featureRequests == "Test Feature Requests")
+    #expect(updatedTexts.newSuggestion == "Test New Suggestion")
 
     // Reset for other tests
     manager.resetToDefault()
@@ -144,7 +146,7 @@ func testTextManagerResetToDefault() async {
     manager.setTexts(mockTexts)
 
     // Verify it's changed
-    #expect(manager.texts.cancel == "Cancelar")
+    #expect(manager.texts.cancel == "Test Cancel")
 
     // When
     manager.resetToDefault()
@@ -243,6 +245,8 @@ func testTextManagerMultipleUpdates() async {
         let beFirstToSuggest = "Soyez le premier à suggérer quelque chose!"
         let featureRequests = "Demandes de fonctionnalités"
         let all = "Toutes"
+        let activeTab = "Actif"
+        let completedTab = "Terminé"
         let pending = "En attente"
         let accepted = "Acceptée"
         let blocked = "Bloquée"
@@ -291,7 +295,7 @@ func testTextManagerMultipleUpdates() async {
 
     // When - Multiple updates
     manager.setTexts(mockTexts1)
-    #expect(manager.texts.cancel == "Cancelar")
+    #expect(manager.texts.cancel == "Test Cancel")
 
     manager.setTexts(mockTexts2)
     #expect(manager.texts.cancel == "Annuler")

--- a/Tests/VoticeTests/VoticeTests.swift
+++ b/Tests/VoticeTests/VoticeTests.swift
@@ -133,6 +133,8 @@ struct VoticeTests {
             let beFirstToSuggest = "Mock Be First"
             let featureRequests = "Mock Feature Requests"
             let all = "Mock All"
+            let activeTab = "Mock Active"
+            let completedTab = "Mock Completed"
             let pending = "Mock Pending"
             let accepted = "Mock Accepted"
             let blocked = "Mock Blocked"


### PR DESCRIPTION
This pull request introduces several new configuration options and UI improvements to the Votice SDK, focusing on suggestion status visibility and filtering, as well as adding support for persisting filter selections. It also updates documentation and dependencies, and includes new utility components and models.

### Configuration and Filtering Enhancements

* Added configuration options to show completed suggestions in a separate tab and to control which optional statuses (`accepted`, `blocked`, `rejected`) are visible in the suggestion list and filter menu. These are managed via new methods and properties in `ConfigurationManager`, with updated documentation in `README.md`. [[1]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R20-R21) [[2]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R42-R48) [[3]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R86-R100) [[4]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R153-R186) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R299-R351)
* Updated the filter menu logic in `FilterMenuView.swift` to dynamically construct the list of visible statuses based on these new configuration options.

### UI Components and Localization

* Added a new `CustomSegmentedControl` SwiftUI component for switching between "Active" and "Completed" tabs.
* Extended `VoticeTextsProtocol` and its implementations to support localized tab titles for "Active" and "Completed" suggestions. [[1]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R36-R37) [[2]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R114-R115) [[3]](diffhunk://#diff-cbe19f9ad04daaf6e72337dfd00d1cb78fa68aaf5cd95614b7ae3f3a21f49035R35-R36)

### Persistence and Storage

* Introduced a new `StorageManager` utility for saving, loading, and deleting Codable objects (e.g., filter selections) using `UserDefaults`.
* Added a new `StorageKey` enum for managing storage keys.
* Updated `SuggestionUseCase` to persist the applied filter status, allowing the filter selection to be remembered across app launches. [[1]](diffhunk://#diff-74dd0ae1727e0b6bae24a4d966bedc66048dc87fb026ec4ad7dc8a91ecd769f0R12-R14) [[2]](diffhunk://#diff-74dd0ae1727e0b6bae24a4d966bedc66048dc87fb026ec4ad7dc8a91ecd769f0R27-R57)

### Dependency and Project Updates

* Updated the SwiftLintPlugins dependency to version 0.61.0 and bumped the SDK version to 1.0.8 in both the codebase and documentation. [[1]](diffhunk://#diff-79b428a616d0156f08f0f75aa7136db2b626ad4f0876faab8f8dac130b883c81L2-R10) [[2]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R42-R48) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44)
* Minor reordering of targets in the Xcode project file for clarity.

---

**References:** [[1]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R20-R21) [[2]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R42-R48) [[3]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R86-R100) [[4]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R153-R186) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R299-R351) [[6]](diffhunk://#diff-85d20923d89bb002492bffc609bedc4407fa43f95b1883cb9a611516382d5a15R18-R52) [[7]](diffhunk://#diff-e65bf99c7c0bc95251a24f2ea6344b23e002ff1b5f49f125ce3a3c9ccbe33b89R1-R90) [[8]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R36-R37) [[9]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R114-R115) [[10]](diffhunk://#diff-cbe19f9ad04daaf6e72337dfd00d1cb78fa68aaf5cd95614b7ae3f3a21f49035R35-R36) [[11]](diffhunk://#diff-d9588a859719c1628970d4d8253b3ad1c0aa302b499144cd691bf01e6c3d3646R1-R48) [[12]](diffhunk://#diff-0487de0f8c0ec8a2f9e29307b9ab687927694adcc33669156d7c4b5aadcd9506R1-R13) [[13]](diffhunk://#diff-74dd0ae1727e0b6bae24a4d966bedc66048dc87fb026ec4ad7dc8a91ecd769f0R12-R14) [[14]](diffhunk://#diff-74dd0ae1727e0b6bae24a4d966bedc66048dc87fb026ec4ad7dc8a91ecd769f0R27-R57) [[15]](diffhunk://#diff-79b428a616d0156f08f0f75aa7136db2b626ad4f0876faab8f8dac130b883c81L2-R10) [[16]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R42-R48) [[17]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[18]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R656-L661)