### PR TITLE
feature: deploy to main branch

### DIFF
--- a/Example/VoticeDemo/VoticeDemo.xcodeproj/project.pbxproj
+++ b/Example/VoticeDemo/VoticeDemo.xcodeproj/project.pbxproj
@@ -318,17 +318,17 @@
 		802F7E572E0F198400F1BDF6 = {
 			isa = PBXGroup;
 			children = (
+				800727602E11AAD500C43BA8 /* Frameworks */,
+				802F7E612E0F198400F1BDF6 /* Products */,
 				802F7E8D2E0F1A2500F1BDF6 /* VoticeDemo */,
-				802F7E922E0F1A2700F1BDF6 /* VoticeDemoTests */,
-				802F7E962E0F1A2900F1BDF6 /* VoticeDemoUITests */,
 				800727572E11AA0700C43BA8 /* VoticeDemo_macOS */,
 				800727512E11AA0700C43BA8 /* VoticeDemo_macOSTests */,
 				8007275D2E11AA0700C43BA8 /* VoticeDemo_macOSUITests */,
 				800727962E11ACFB00C43BA8 /* VoticeDemo_tvOS */,
 				800727912E11ACFB00C43BA8 /* VoticeDemo_tvOSTests */,
 				8007279C2E11ACFB00C43BA8 /* VoticeDemo_tvOSUITests */,
-				800727602E11AAD500C43BA8 /* Frameworks */,
-				802F7E612E0F198400F1BDF6 /* Products */,
+				802F7E922E0F1A2700F1BDF6 /* VoticeDemoTests */,
+				802F7E962E0F1A2900F1BDF6 /* VoticeDemoUITests */,
 			);
 			sourceTree = "<group>";
 		};

--- a/Example/VoticeDemo/VoticeDemo.xcodeproj/project.pbxproj
+++ b/Example/VoticeDemo/VoticeDemo.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 				800727242E11A9FC00C43BA8 /* Sources */,
 				800727252E11A9FC00C43BA8 /* Frameworks */,
 				800727262E11A9FC00C43BA8 /* Resources */,
+				808722072E89696E000AA252 /* SwiftLint Script */,
 			);
 			buildRules = (
 			);
@@ -492,6 +493,7 @@
 				800727632E11ACD400C43BA8 /* Sources */,
 				800727642E11ACD400C43BA8 /* Frameworks */,
 				800727652E11ACD400C43BA8 /* Resources */,
+				808722082E89697D000AA252 /* SwiftLint Script */,
 			);
 			buildRules = (
 			);
@@ -803,6 +805,44 @@
 			shellPath = /bin/sh;
 			shellScript = "SWIFT_PACKAGE_DIR=\"${BUILD_DIR%Build/*}SourcePackages/artifacts\"\nSWIFTLINT_CMD=$(ls \"$SWIFT_PACKAGE_DIR\"/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*-macos/bin/swiftlint | head -n 1)\n\nif test -f \"$SWIFTLINT_CMD\" 2>&1\nthen\n    \"$SWIFTLINT_CMD\"\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
+		808722072E89696E000AA252 /* SwiftLint Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "SwiftLint Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "SWIFT_PACKAGE_DIR=\"${BUILD_DIR%Build/*}SourcePackages/artifacts\"\nSWIFTLINT_CMD=$(ls \"$SWIFT_PACKAGE_DIR\"/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*-macos/bin/swiftlint | head -n 1)\n\nif test -f \"$SWIFTLINT_CMD\" 2>&1\nthen\n    \"$SWIFTLINT_CMD\"\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
+		};
+		808722082E89697D000AA252 /* SwiftLint Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "SwiftLint Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "SWIFT_PACKAGE_DIR=\"${BUILD_DIR%Build/*}SourcePackages/artifacts\"\nSWIFTLINT_CMD=$(ls \"$SWIFT_PACKAGE_DIR\"/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*-macos/bin/swiftlint | head -n 1)\n\nif test -f \"$SWIFTLINT_CMD\" 2>&1\nthen\n    \"$SWIFTLINT_CMD\"\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -948,6 +988,7 @@
 				DEVELOPMENT_TEAM = Q4X55987WE;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "VoticeDemo-macOS-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = VoticeDemo;
@@ -981,6 +1022,7 @@
 				DEVELOPMENT_TEAM = Q4X55987WE;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "VoticeDemo-macOS-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = VoticeDemo;
@@ -1085,6 +1127,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = Q4X55987WE;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "VoticeDemo-tvOS-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = VoticeDemo;
@@ -1116,6 +1159,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = Q4X55987WE;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "VoticeDemo-tvOS-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = VoticeDemo;

--- a/Example/VoticeDemo/VoticeDemo/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo/HomeView.swift
@@ -129,6 +129,7 @@ private extension HomeView {
             Votice.setCommentIsEnabled(enabled: true)
             Votice.setShowCompletedSeparately(enabled: true)
             Votice.setVisibleOptionalStatuses(accepted: true, blocked: false, rejected: false)
+            Votice.setUserIsPremium(isPremium: true)
 
             isConfigured = Votice.isConfigured
 

--- a/Example/VoticeDemo/VoticeDemo/Shared/App/SpanishTexts.swift
+++ b/Example/VoticeDemo/VoticeDemo/Shared/App/SpanishTexts.swift
@@ -92,4 +92,6 @@ struct SpanishTexts: VoticeTextsProtocol {
     let attachImage = "Adjuntar imagen (opcional)"
     let titleIssueImage = "Imagen de la incidencia"
     let loadingImage = "Cargando imagen..."
+    let dragAndDropImage = "Arrastra y suelta una imagen aquí"
+    let or = "o"
 }

--- a/Example/VoticeDemo/VoticeDemo/Shared/App/SpanishTexts.swift
+++ b/Example/VoticeDemo/VoticeDemo/Shared/App/SpanishTexts.swift
@@ -90,4 +90,6 @@ struct SpanishTexts: VoticeTextsProtocol {
     let titleIssuePlaceholder = "Introduce un título breve para el problema"
     let descriptionIssuePlaceholder = "Describe el problema en detalle..."
     let attachImage = "Adjuntar imagen (opcional)"
+    let titleIssueImage = "Imagen de la incidencia"
+    let loadingImage = "Cargando imagen..."
 }

--- a/Example/VoticeDemo/VoticeDemo/Shared/App/SpanishTexts.swift
+++ b/Example/VoticeDemo/VoticeDemo/Shared/App/SpanishTexts.swift
@@ -82,4 +82,12 @@ struct SpanishTexts: VoticeTextsProtocol {
     let yourNameOptionalCreate = "Tu nombre (opcional)"
     let enterYourNameCreate = "Introduce tu nombre"
     let leaveEmptyAnonymous = "Déjalo vacío para enviar anónimamente"
+
+    // MARK: - Create Issue (optional feature)
+
+    let reportIssue = "Reportar un problema"
+    let reportIssueSubtitle = "¿Has encontrado un error o problema?"
+    let titleIssuePlaceholder = "Introduce un título breve para el problema"
+    let descriptionIssuePlaceholder = "Describe el problema en detalle..."
+    let attachImage = "Adjuntar imagen (opcional)"
 }

--- a/Example/VoticeDemo/VoticeDemo_macOS/AppVoticeDemo.swift
+++ b/Example/VoticeDemo/VoticeDemo_macOS/AppVoticeDemo.swift
@@ -15,7 +15,7 @@ struct AppVoticeDemo: App {
     var body: some Scene {
         WindowGroup {
             HomeView()
-                .frame(minWidth: 800, minHeight: 600)
+                .frame(minWidth: 1200, minHeight: 720)
         }
     }
 }

--- a/Example/VoticeDemo/VoticeDemo_macOS/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo_macOS/HomeView.swift
@@ -75,6 +75,7 @@ private extension HomeView {
             Votice.setCommentIsEnabled(enabled: true)
             Votice.setShowCompletedSeparately(enabled: true)
             Votice.setVisibleOptionalStatuses(accepted: true, blocked: false, rejected: false)
+            Votice.setUserIsPremium(isPremium: false)
 
             isConfigured = Votice.isConfigured
 

--- a/Example/VoticeDemo/VoticeDemo_tvOS/HomeView.swift
+++ b/Example/VoticeDemo/VoticeDemo_tvOS/HomeView.swift
@@ -77,6 +77,7 @@ private extension HomeView {
             Votice.setCommentIsEnabled(enabled: true)
             Votice.setShowCompletedSeparately(enabled: false)
             Votice.setVisibleOptionalStatuses(accepted: true, blocked: true, rejected: true)
+            Votice.setUserIsPremium(isPremium: false)
 
             isConfigured = Votice.isConfigured
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Votice.feedbackView(theme: theme)
 
 > ℹ️ If you do not configure custom fonts, the SDK will use the default system fonts.
 
-### 6. Comment on susgestions (Optional)
+### 6. Comment on suggestions (Optional)
 
 You can allow users to comment on suggestions by enabling the comments feature (Default is enabled):
 
@@ -271,7 +271,15 @@ You can allow users to comment on suggestions by enabling the comments feature (
 Votice.setCommentIsEnabled(enabled: Bool)
 ```
 
-### 7. Debug Logging (Optional)
+### 7. User is premium (Optional)
+
+If you want to mark the current user as a premium user (Default is false), you can do so with:
+
+```swift
+Votice.setUserIsPremium(isPremium: Bool)
+```
+
+### 8. Debug Logging (Optional)
 
 By default, Votice SDK runs silently to avoid cluttering your development console. If you need to troubleshoot SDK issues or see internal operations, you can enable debug logging (Default is disabled):
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The Votice management app for handling suggestions and apps is available for dow
 Add this line to your `Package.swift` dependencies:
 
 ```swift
-.package(url: "https://github.com/artcc/votice-sdk", from: "1.0.9"),
+.package(url: "https://github.com/artcc/votice-sdk", from: "1.0.10"),
 ```
 
 Or via Xcode:

--- a/Sources/Votice/Core/Managers/ConfigurationManager.swift
+++ b/Sources/Votice/Core/Managers/ConfigurationManager.swift
@@ -45,7 +45,7 @@ final class ConfigurationManager: ConfigurationManagerProtocol, @unchecked Senda
     private let lock = NSLock()
     private let _baseURL = "https://api.votice.app/api"
     private let _configurationId = UUID().uuidString
-    private let _version = "1.0.9"
+    private let _version = "1.0.10"
     private let _buildNumber = "1"
 
     // MARK: - Public properties

--- a/Sources/Votice/Core/Managers/ConfigurationManager.swift
+++ b/Sources/Votice/Core/Managers/ConfigurationManager.swift
@@ -18,6 +18,7 @@ protocol ConfigurationManagerProtocol: Sendable {
     var appId: String { get }
     var commentIsEnabled: Bool { get set }
     var showCompletedSeparately: Bool { get set }
+    var user: UserEntity { get set }
     var optionalVisibleStatuses: Set<SuggestionStatusEntity> { get }
     var version: String { get }
     var buildNumber: String { get }
@@ -40,6 +41,7 @@ final class ConfigurationManager: ConfigurationManagerProtocol, @unchecked Senda
     private var _isConfigured = false
     private var _commentIsEnabled = true
     private var _showCompletedSeparately = false
+    private var _user = UserEntity(isPremium: false)
     private var _optionalVisibleStatuses: Set<SuggestionStatusEntity> = [.accepted, .blocked, .rejected]
 
     private let lock = NSLock()
@@ -89,6 +91,15 @@ final class ConfigurationManager: ConfigurationManagerProtocol, @unchecked Senda
         }
         set {
             lock.withLock { _showCompletedSeparately = newValue }
+        }
+    }
+
+    var user: UserEntity {
+        get {
+            lock.withLock { _user }
+        }
+        set {
+            lock.withLock { _user = newValue }
         }
     }
 

--- a/Sources/Votice/Core/Managers/StorageManager.swift
+++ b/Sources/Votice/Core/Managers/StorageManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol StorageManagerProtocol {
+protocol StorageManagerProtocol: Sendable {
     func save<T: Codable>(_ object: T, forKey key: String) throws
     func load<T: Codable>(forKey key: String, as type: T.Type) throws -> T?
     func delete(forKey key: String) throws
@@ -17,7 +17,7 @@ protocol StorageManagerProtocol {
 final class StorageManager: StorageManagerProtocol {
     // MARK: - Properties
 
-    private let userDefaults: UserDefaults
+    private nonisolated(unsafe) let userDefaults: UserDefaults
 
     // MARK: - Init
 

--- a/Sources/Votice/Core/Managers/TextManager.swift
+++ b/Sources/Votice/Core/Managers/TextManager.swift
@@ -91,6 +91,8 @@ public protocol VoticeTextsProtocol: Sendable {
     var titleIssuePlaceholder: String { get }
     var descriptionIssuePlaceholder: String { get }
     var attachImage: String { get }
+    var titleIssueImage: String { get }
+    var loadingImage: String { get }
 }
 
 // MARK: - DefaultVoticeTexts
@@ -177,6 +179,8 @@ public struct DefaultVoticeTexts: VoticeTextsProtocol {
     public let titleIssuePlaceholder = "Enter a brief title for the issue"
     public let descriptionIssuePlaceholder = "Describe the issue in detail..."
     public let attachImage = "Attach Image"
+    public let titleIssueImage = "Issue Image"
+    public let loadingImage = "Loading image..."
 }
 
 // MARK: - TextManager

--- a/Sources/Votice/Core/Managers/TextManager.swift
+++ b/Sources/Votice/Core/Managers/TextManager.swift
@@ -172,11 +172,11 @@ public struct DefaultVoticeTexts: VoticeTextsProtocol {
 
     // MARK: - Create Issue (optional feature)
 
-    public let reportIssue = "Report an Issue"
-    public let reportIssueSubtitle = "Help us fix it by describing the problem you encountered."
+    public let reportIssue = "Report Issue"
+    public let reportIssueSubtitle = "Help us fix it by describing the issue you encountered."
     public let titleIssuePlaceholder = "Enter a brief title for the issue"
     public let descriptionIssuePlaceholder = "Describe the issue in detail..."
-    public let attachImage = "Attach image"
+    public let attachImage = "Attach Image"
 }
 
 // MARK: - TextManager

--- a/Sources/Votice/Core/Managers/TextManager.swift
+++ b/Sources/Votice/Core/Managers/TextManager.swift
@@ -83,6 +83,14 @@ public protocol VoticeTextsProtocol: Sendable {
     var yourNameOptionalCreate: String { get }
     var enterYourNameCreate: String { get }
     var leaveEmptyAnonymous: String { get }
+
+    // MARK: - Create Issue (optional feature)
+
+    var reportIssue: String { get }
+    var reportIssueSubtitle: String { get }
+    var titleIssuePlaceholder: String { get }
+    var descriptionIssuePlaceholder: String { get }
+    var attachImage: String { get }
 }
 
 // MARK: - DefaultVoticeTexts
@@ -161,6 +169,14 @@ public struct DefaultVoticeTexts: VoticeTextsProtocol {
     public let yourNameOptionalCreate = "Your Name (Optional)"
     public let enterYourNameCreate = "Enter your name"
     public let leaveEmptyAnonymous = "Leave empty to submit anonymously"
+
+    // MARK: - Create Issue (optional feature)
+
+    public let reportIssue = "Report an Issue"
+    public let reportIssueSubtitle = "Help us fix it by describing the problem you encountered."
+    public let titleIssuePlaceholder = "Enter a brief title for the issue"
+    public let descriptionIssuePlaceholder = "Describe the issue in detail..."
+    public let attachImage = "Attach image"
 }
 
 // MARK: - TextManager

--- a/Sources/Votice/Core/Managers/TextManager.swift
+++ b/Sources/Votice/Core/Managers/TextManager.swift
@@ -93,6 +93,8 @@ public protocol VoticeTextsProtocol: Sendable {
     var attachImage: String { get }
     var titleIssueImage: String { get }
     var loadingImage: String { get }
+    var dragAndDropImage: String { get }
+    var or: String { get }
 }
 
 // MARK: - DefaultVoticeTexts
@@ -181,6 +183,8 @@ public struct DefaultVoticeTexts: VoticeTextsProtocol {
     public let attachImage = "Attach Image"
     public let titleIssueImage = "Issue Image"
     public let loadingImage = "Loading image..."
+    public let dragAndDropImage = "Drag image here"
+    public let or = "or"
 }
 
 // MARK: - TextManager

--- a/Sources/Votice/Core/Models/Error/VoticeError.swift
+++ b/Sources/Votice/Core/Models/Error/VoticeError.swift
@@ -11,6 +11,7 @@ import Foundation
 enum VoticeError: Error, LocalizedError, Sendable {
     // MARK: - Cases
 
+    case general
     case invalidInput(String)
     case networkError(Error)
     case configurationError(ConfigurationError)
@@ -20,6 +21,8 @@ enum VoticeError: Error, LocalizedError, Sendable {
 
     var errorDescription: String? {
         switch self {
+        case .general:
+            return "An unexpected error occurred."
         case .invalidInput(let message):
             return "Invalid input: \(message)"
         case .networkError(let error):

--- a/Sources/Votice/Core/Models/Request/CreateSuggestionRequest.swift
+++ b/Sources/Votice/Core/Models/Request/CreateSuggestionRequest.swift
@@ -13,21 +13,25 @@ struct CreateSuggestionRequest: Codable, Sendable {
 
     let title: String
     let description: String?
-    let deviceId: String
+    let deviceId: String?
     let nickname: String?
-    let platform: String
-    let language: String
+    let platform: String?
+    let language: String?
     let userIsPremium: Bool
+    let issue: Bool
+    let urlImage: String?
 
     // MARK: - Init
 
     init(title: String,
          description: String? = nil,
-         deviceId: String,
+         deviceId: String? = nil,
          nickname: String? = nil,
-         platform: String,
-         language: String,
-         userIsPremium: Bool) {
+         platform: String? = nil,
+         language: String? = nil,
+         userIsPremium: Bool,
+         issue: Bool,
+         urlImage: String? = nil) {
         self.title = title
         self.description = description
         self.deviceId = deviceId
@@ -35,5 +39,7 @@ struct CreateSuggestionRequest: Codable, Sendable {
         self.platform = platform
         self.language = language
         self.userIsPremium = userIsPremium
+        self.issue = issue
+        self.urlImage = urlImage
     }
 }

--- a/Sources/Votice/Core/Models/Request/CreateSuggestionRequest.swift
+++ b/Sources/Votice/Core/Models/Request/CreateSuggestionRequest.swift
@@ -17,6 +17,7 @@ struct CreateSuggestionRequest: Codable, Sendable {
     let nickname: String?
     let platform: String
     let language: String
+    let userIsPremium: Bool
 
     // MARK: - Init
 
@@ -25,12 +26,14 @@ struct CreateSuggestionRequest: Codable, Sendable {
          deviceId: String,
          nickname: String? = nil,
          platform: String,
-         language: String) {
+         language: String,
+         userIsPremium: Bool) {
         self.title = title
         self.description = description
         self.deviceId = deviceId
         self.nickname = nickname
         self.platform = platform
         self.language = language
+        self.userIsPremium = userIsPremium
     }
 }

--- a/Sources/Votice/Core/Models/Request/UploadImageRequest.swift
+++ b/Sources/Votice/Core/Models/Request/UploadImageRequest.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct UploadImageRequest: Codable, Sendable {
-    let imageData: Data
+    let imageData: String
     let fileName: String
+    let mimeType: String
 }

--- a/Sources/Votice/Core/Models/Request/UploadImageRequest.swift
+++ b/Sources/Votice/Core/Models/Request/UploadImageRequest.swift
@@ -1,0 +1,14 @@
+//
+//  UploadImageRequest.swift
+//  Votice
+//
+//  Created by Arturo Carretero Calvo on 28/9/25.
+//  Copyright © 2025 ArtCC. All rights reserved.
+//
+
+import Foundation
+
+struct UploadImageRequest: Codable, Sendable {
+    let imageData: Data
+    let fileName: String
+}

--- a/Sources/Votice/Core/Models/Response/UploadImageResponse.swift
+++ b/Sources/Votice/Core/Models/Response/UploadImageResponse.swift
@@ -1,0 +1,15 @@
+//
+//  UploadImageResponse.swift
+//  Votice
+//
+//  Created by Arturo Carretero Calvo on 28/9/25.
+//  Copyright © 2025 ArtCC. All rights reserved.
+//
+
+import Foundation
+
+struct UploadImageResponse: Codable, Sendable {
+    let message: String
+    let imageUrl: String
+    let fileName: String
+}

--- a/Sources/Votice/Core/Models/SuggestionEntity.swift
+++ b/Sources/Votice/Core/Models/SuggestionEntity.swift
@@ -11,6 +11,7 @@ import Foundation
 struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
     // MARK: - Properties
 
+    var commentCount: Int?
     let id: String
     let appId: String?
     let title: String?
@@ -24,11 +25,10 @@ struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
     let deviceId: String?
     let status: SuggestionStatusEntity?
     let source: SuggestionSource?
-    let commentCount: Int?
     let voteCount: Int?
     let language: String?
-    let userIsPremium: Bool
-    let issue: Bool
+    let userIsPremium: Bool?
+    let issue: Bool?
     let urlImage: String?
 
     // MARK: - Init
@@ -49,8 +49,8 @@ struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
          commentCount: Int? = nil,
          voteCount: Int? = nil,
          language: String? = nil,
-         userIsPremium: Bool = false,
-         issue: Bool = false,
+         userIsPremium: Bool? = false,
+         issue: Bool? = false,
          urlImage: String? = nil) {
         self.id = id
         self.appId = appId
@@ -109,8 +109,8 @@ extension SuggestionEntity {
         commentCount: Int? = nil,
         voteCount: Int? = nil,
         language: String? = nil,
-        userIsPremium: Bool = false,
-        issue: Bool = false,
+        userIsPremium: Bool? = false,
+        issue: Bool? = false,
         urlImage: String? = nil
     ) -> SuggestionEntity {
         SuggestionEntity(
@@ -130,8 +130,8 @@ extension SuggestionEntity {
             commentCount: commentCount ?? self.commentCount,
             voteCount: voteCount ?? self.voteCount,
             language: language ?? self.language,
-            userIsPremium: userIsPremium,
-            issue: issue,
+            userIsPremium: userIsPremium ?? self.userIsPremium,
+            issue: issue ?? self.issue,
             urlImage: urlImage ?? self.urlImage
         )
     }

--- a/Sources/Votice/Core/Models/SuggestionEntity.swift
+++ b/Sources/Votice/Core/Models/SuggestionEntity.swift
@@ -28,6 +28,8 @@ struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
     let voteCount: Int?
     let language: String?
     let userIsPremium: Bool
+    let issue: Bool
+    let urlImage: String?
 
     // MARK: - Init
 
@@ -47,7 +49,9 @@ struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
          commentCount: Int? = nil,
          voteCount: Int? = nil,
          language: String? = nil,
-         userIsPremium: Bool = false) {
+         userIsPremium: Bool = false,
+         issue: Bool = false,
+         urlImage: String? = nil) {
         self.id = id
         self.appId = appId
         self.title = title
@@ -65,6 +69,8 @@ struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
         self.voteCount = voteCount
         self.language = language
         self.userIsPremium = userIsPremium
+        self.issue = issue
+        self.urlImage = urlImage
     }
 }
 
@@ -103,7 +109,9 @@ extension SuggestionEntity {
         commentCount: Int? = nil,
         voteCount: Int? = nil,
         language: String? = nil,
-        userIsPremium: Bool = false
+        userIsPremium: Bool = false,
+        issue: Bool = false,
+        urlImage: String? = nil
     ) -> SuggestionEntity {
         SuggestionEntity(
             id: id ?? self.id,
@@ -122,7 +130,9 @@ extension SuggestionEntity {
             commentCount: commentCount ?? self.commentCount,
             voteCount: voteCount ?? self.voteCount,
             language: language ?? self.language,
-            userIsPremium: userIsPremium
+            userIsPremium: userIsPremium,
+            issue: issue,
+            urlImage: urlImage ?? self.urlImage
         )
     }
 }

--- a/Sources/Votice/Core/Models/SuggestionEntity.swift
+++ b/Sources/Votice/Core/Models/SuggestionEntity.swift
@@ -27,6 +27,7 @@ struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
     let commentCount: Int?
     let voteCount: Int?
     let language: String?
+    let userIsPremium: Bool
 
     // MARK: - Init
 
@@ -45,7 +46,8 @@ struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
          source: SuggestionSource? = nil,
          commentCount: Int? = nil,
          voteCount: Int? = nil,
-         language: String? = nil) {
+         language: String? = nil,
+         userIsPremium: Bool = false) {
         self.id = id
         self.appId = appId
         self.title = title
@@ -62,6 +64,7 @@ struct SuggestionEntity: Codable, Equatable, Identifiable, Sendable {
         self.commentCount = commentCount
         self.voteCount = voteCount
         self.language = language
+        self.userIsPremium = userIsPremium
     }
 }
 
@@ -83,37 +86,43 @@ extension SuggestionEntity {
 
     // MARK: - Functions
 
-    func copyWith(id: String? = nil,
-                  appId: String? = nil,
-                  title: String? = nil,
-                  text: String? = nil,
-                  description: String? = nil,
-                  nickname: String? = nil,
-                  createdAt: String? = nil,
-                  updatedAt: String? = nil,
-                  platform: String? = nil,
-                  createdBy: String? = nil,
-                  deviceId: String? = nil,
-                  status: SuggestionStatusEntity? = nil,
-                  source: SuggestionSource? = nil,
-                  commentCount: Int? = nil,
-                  voteCount: Int? = nil,
-                  language: String? = nil) -> SuggestionEntity {
-        SuggestionEntity(id: id ?? self.id,
-                         appId: appId ?? self.appId,
-                         title: title ?? self.title,
-                         text: text ?? self.text,
-                         description: description ?? self.description,
-                         nickname: nickname ?? self.nickname,
-                         createdAt: createdAt ?? self.createdAt,
-                         updatedAt: updatedAt ?? self.updatedAt,
-                         platform: platform ?? self.platform,
-                         createdBy: createdBy ?? self.createdBy,
-                         deviceId: deviceId ?? self.deviceId,
-                         status: status ?? self.status,
-                         source: source ?? self.source,
-                         commentCount: commentCount ?? self.commentCount,
-                         voteCount: voteCount ?? self.voteCount,
-                         language: language ?? self.language)
+    func copyWith(
+        id: String? = nil,
+        appId: String? = nil,
+        title: String? = nil,
+        text: String? = nil,
+        description: String? = nil,
+        nickname: String? = nil,
+        createdAt: String? = nil,
+        updatedAt: String? = nil,
+        platform: String? = nil,
+        createdBy: String? = nil,
+        deviceId: String? = nil,
+        status: SuggestionStatusEntity? = nil,
+        source: SuggestionSource? = nil,
+        commentCount: Int? = nil,
+        voteCount: Int? = nil,
+        language: String? = nil,
+        userIsPremium: Bool = false
+    ) -> SuggestionEntity {
+        SuggestionEntity(
+            id: id ?? self.id,
+            appId: appId ?? self.appId,
+            title: title ?? self.title,
+            text: text ?? self.text,
+            description: description ?? self.description,
+            nickname: nickname ?? self.nickname,
+            createdAt: createdAt ?? self.createdAt,
+            updatedAt: updatedAt ?? self.updatedAt,
+            platform: platform ?? self.platform,
+            createdBy: createdBy ?? self.createdBy,
+            deviceId: deviceId ?? self.deviceId,
+            status: status ?? self.status,
+            source: source ?? self.source,
+            commentCount: commentCount ?? self.commentCount,
+            voteCount: voteCount ?? self.voteCount,
+            language: language ?? self.language,
+            userIsPremium: userIsPremium
+        )
     }
 }

--- a/Sources/Votice/Core/Models/UserEntity.swift
+++ b/Sources/Votice/Core/Models/UserEntity.swift
@@ -1,0 +1,15 @@
+//
+//  UserEntity.swift
+//  Votice
+//
+//  Created by Arturo Carretero Calvo on 26/9/25.
+//  Copyright © 2025 ArtCC. All rights reserved.
+//
+
+import Foundation
+
+public struct UserEntity: Sendable, Codable {
+    // MARK: - Properties
+
+    public let isPremium: Bool
+}

--- a/Sources/Votice/Core/Repositories/SuggestionRepository.swift
+++ b/Sources/Votice/Core/Repositories/SuggestionRepository.swift
@@ -86,13 +86,7 @@ final class SuggestionRepository: SuggestionRepositoryProtocol {
     }
 
     func uploadImage(request: UploadImageRequest) async throws -> UploadImageResponse {
-        let base64String = request.imageData.base64EncodedString()
-        let requestBody: [String: Any] = [
-            "imageData": "data:image/jpeg;base64,\(base64String)",
-            "fileName": request.fileName,
-            "mimeType": "image/jpeg"
-        ]
-        let bodyData = try JSONSerialization.data(withJSONObject: requestBody)
+        let bodyData = try JSONEncoder().encode(request)
         let endpoint = NetworkEndpoint(path: "/v1/sdk/suggestions/upload-image", method: .POST, body: bodyData)
 
         return try await networkManager.request(endpoint: endpoint, responseType: UploadImageResponse.self)

--- a/Sources/Votice/Core/Repositories/SuggestionRepository.swift
+++ b/Sources/Votice/Core/Repositories/SuggestionRepository.swift
@@ -15,6 +15,7 @@ protocol SuggestionRepositoryProtocol: Sendable {
     func fetchVoteStatus(request: VoteStatusRequest) async throws -> VoteStatusEntity
     func voteSuggestion(request: VoteSuggestionRequest) async throws -> VoteSuggestionResponse
     func unvoteSuggestion(request: VoteSuggestionRequest) async throws -> VoteSuggestionResponse
+    func uploadImage(request: UploadImageRequest) async throws -> UploadImageResponse
 }
 
 final class SuggestionRepository: SuggestionRepositoryProtocol {
@@ -82,5 +83,18 @@ final class SuggestionRepository: SuggestionRepositoryProtocol {
         let endpoint = NetworkEndpoint(path: "/v1/sdk/votes/unvote", method: .POST, body: bodyData)
 
         return try await networkManager.request(endpoint: endpoint, responseType: VoteSuggestionResponse.self)
+    }
+
+    func uploadImage(request: UploadImageRequest) async throws -> UploadImageResponse {
+        let base64String = request.imageData.base64EncodedString()
+        let requestBody: [String: Any] = [
+            "imageData": "data:image/jpeg;base64,\(base64String)",
+            "fileName": request.fileName,
+            "mimeType": "image/jpeg"
+        ]
+        let bodyData = try JSONSerialization.data(withJSONObject: requestBody)
+        let endpoint = NetworkEndpoint(path: "/v1/sdk/suggestions/upload-image", method: .POST, body: bodyData)
+
+        return try await networkManager.request(endpoint: endpoint, responseType: UploadImageResponse.self)
     }
 }

--- a/Sources/Votice/Core/UseCases/CommentUseCase.swift
+++ b/Sources/Votice/Core/UseCases/CommentUseCase.swift
@@ -56,10 +56,12 @@ final class CommentUseCase: CommentUseCaseProtocol {
             throw VoticeError.invalidInput("Comment content cannot be empty")
         }
 
-        let request = CreateCommentRequest(suggestionId: suggestionId,
-                                           text: text,
-                                           deviceId: deviceManager.deviceId,
-                                           nickname: nickname)
+        let request = CreateCommentRequest(
+            suggestionId: suggestionId,
+            text: text,
+            deviceId: deviceManager.deviceId,
+            nickname: nickname
+        )
 
         return try await commentRepository.createComment(request: request)
     }

--- a/Sources/Votice/Core/UseCases/SuggestionUseCase.swift
+++ b/Sources/Votice/Core/UseCases/SuggestionUseCase.swift
@@ -17,6 +17,7 @@ protocol SuggestionUseCaseProtocol: Sendable {
     func deleteSuggestion(suggestionId: String) async throws -> DeleteSuggestionResponse
     func fetchVoteStatus(suggestionId: String) async throws -> VoteStatusEntity
     func vote(suggestionId: String, voteType: VoteType) async throws -> VoteSuggestionResponse
+    func uploadImage(request: UploadImageRequest) async throws -> UploadImageResponse
 }
 
 final class SuggestionUseCase: SuggestionUseCaseProtocol {
@@ -126,5 +127,19 @@ final class SuggestionUseCase: SuggestionUseCaseProtocol {
         case .downvote:
             return try await suggestionRepository.unvoteSuggestion(request: request)
         }
+    }
+
+    func uploadImage(request: UploadImageRequest) async throws -> UploadImageResponse {
+        try configurationManager.validateConfiguration()
+
+        guard !request.fileName.isEmpty else {
+            throw VoticeError.invalidInput("File name cannot be empty")
+        }
+
+        guard !request.imageData.isEmpty else {
+            throw VoticeError.invalidInput("Image data cannot be empty")
+        }
+
+        return try await suggestionRepository.uploadImage(request: request)
     }
 }

--- a/Sources/Votice/Core/UseCases/SuggestionUseCase.swift
+++ b/Sources/Votice/Core/UseCases/SuggestionUseCase.swift
@@ -13,12 +13,7 @@ protocol SuggestionUseCaseProtocol: Sendable {
     func setFilterApplied(_ status: SuggestionStatusEntity?) throws
     func clearFilterApplied() throws
     func fetchSuggestions(pagination: PaginationRequest) async throws -> SuggestionsResponse
-    func createSuggestion(
-        title: String,
-        description: String?,
-        nickname: String?,
-        userIsPremium: Bool
-    ) async throws -> CreateSuggestionResponse
+    func createSuggestion(request: CreateSuggestionRequest) async throws -> CreateSuggestionResponse
     func deleteSuggestion(suggestionId: String) async throws -> DeleteSuggestionResponse
     func fetchVoteStatus(suggestionId: String) async throws -> VoteStatusEntity
     func vote(suggestionId: String, voteType: VoteType) async throws -> VoteSuggestionResponse
@@ -66,29 +61,26 @@ final class SuggestionUseCase: SuggestionUseCaseProtocol {
         return try await suggestionRepository.fetchSuggestions(request: request)
     }
 
-    func createSuggestion(
-        title: String,
-        description: String?,
-        nickname: String?,
-        userIsPremium: Bool
-    ) async throws -> CreateSuggestionResponse {
+    func createSuggestion(request: CreateSuggestionRequest) async throws -> CreateSuggestionResponse {
         try configurationManager.validateConfiguration()
 
-        guard !title.isEmpty else {
+        guard !request.title.isEmpty else {
             throw VoticeError.invalidInput("Title cannot be empty")
         }
 
-        let request = CreateSuggestionRequest(
-            title: title,
-            description: description,
+        let entity = CreateSuggestionRequest(
+            title: request.title,
+            description: request.description,
             deviceId: deviceManager.deviceId,
-            nickname: nickname,
+            nickname: request.nickname,
             platform: deviceManager.platform,
             language: deviceManager.language,
-            userIsPremium: userIsPremium
+            userIsPremium: request.userIsPremium,
+            issue: request.issue,
+            urlImage: request.urlImage
         )
 
-        return try await suggestionRepository.createSuggestion(request: request)
+        return try await suggestionRepository.createSuggestion(request: entity)
     }
 
     func deleteSuggestion(suggestionId: String) async throws -> DeleteSuggestionResponse {

--- a/Sources/Votice/Core/UseCases/VersionUseCase.swift
+++ b/Sources/Votice/Core/UseCases/VersionUseCase.swift
@@ -18,7 +18,7 @@ final class VersionUseCase: VersionUseCaseProtocol {
     private let versionRepository: VersionRepositoryProtocol
     private let configurationManager: ConfigurationManagerProtocol
     private let deviceManager: DeviceManagerProtocol
-    private let userDefaults: UserDefaults
+    private nonisolated(unsafe) let userDefaults: UserDefaults
     private let lastReportKey = "Votice_LastVersionReportDate"
     private let reportInterval: TimeInterval = 60 * 60 * 24 * 3 // 3 days
 
@@ -46,10 +46,11 @@ final class VersionUseCase: VersionUseCaseProtocol {
 
         try configurationManager.validateConfiguration()
 
-        let request: VersionRequest = .init(version: configurationManager.version,
-                                            buildNumber: configurationManager.buildNumber,
-                                            platform: deviceManager.platform)
-
+        let request: VersionRequest = .init(
+            version: configurationManager.version,
+            buildNumber: configurationManager.buildNumber,
+            platform: deviceManager.platform
+        )
         let response = try await versionRepository.report(request: request)
 
         userDefaults.set(now, forKey: lastReportKey)

--- a/Sources/Votice/UI/Components/SuggestionCard.swift
+++ b/Sources/Votice/UI/Components/SuggestionCard.swift
@@ -103,7 +103,7 @@ private extension SuggestionCard {
     var titleView: some View {
         VStack(spacing: theme.spacing.sm) {
             HStack(spacing: 5) {
-                if suggestion.issue {
+                if let issue = suggestion.issue, issue {
                     Image(systemName: "ladybug.fill")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(theme.colors.pending)

--- a/Sources/Votice/UI/Components/SuggestionCard.swift
+++ b/Sources/Votice/UI/Components/SuggestionCard.swift
@@ -26,10 +26,12 @@ struct SuggestionCard: View {
         ZStack(alignment: .topTrailing) {
             HStack(alignment: .center, spacing: theme.spacing.md) {
                 VStack(spacing: theme.spacing.sm) {
-                    VotingButtons(upvotes: max(0, suggestion.voteCount ?? 0),
-                                  downvotes: 0,
-                                  currentVote: currentVote,
-                                  onVote: onVote)
+                    VotingButtons(
+                        upvotes: max(0, suggestion.voteCount ?? 0),
+                        downvotes: 0,
+                        currentVote: currentVote,
+                        onVote: onVote
+                    )
                     if ConfigurationManager.shared.commentIsEnabled, suggestion.commentCount ?? 0 > 0 {
                         VStack(spacing: 4) {
                             Image(systemName: "bubble.left.fill")
@@ -100,7 +102,12 @@ struct SuggestionCard: View {
 private extension SuggestionCard {
     var titleView: some View {
         VStack(spacing: theme.spacing.sm) {
-            HStack {
+            HStack(spacing: 5) {
+                if suggestion.issue {
+                    Image(systemName: "ladybug.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(theme.colors.pending)
+                }
                 Text(suggestion.displayText)
                     .font(theme.typography.headline)
                     .foregroundColor(theme.colors.onSurface)

--- a/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionView+Functions.swift
+++ b/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionView+Functions.swift
@@ -1,0 +1,98 @@
+//
+//  CreateSuggestionView+Functions.swift
+//  Votice
+//
+//  Created by Arturo Carretero Calvo on 28/9/25.
+//  Copyright © 2025 ArtCC. All rights reserved.
+//
+
+import SwiftUI
+
+extension CreateSuggestionView {
+#if os(macOS)
+    func handleImageDrop(providers: [NSItemProvider]) -> Bool {
+        guard let provider = providers.first else {
+            return false
+        }
+
+        if provider.canLoadObject(ofClass: NSImage.self) {
+            provider.loadObject(ofClass: NSImage.self) { image, _ in
+                if let nsImage = image as? NSImage,
+                   let imageData = nsImage.tiffRepresentation,
+                   let bitmap = NSBitmapImageRep(data: imageData),
+                   let jpegData = bitmap.representation(using: .jpeg, properties: [:]) {
+                    DispatchQueue.main.async {
+                        if let compressedData = compressImageData(jpegData) {
+                            viewModel.setIssueImage(compressedData)
+                        }
+                    }
+                }
+            }
+
+            return true
+        }
+
+        if provider.hasItemConformingToTypeIdentifier("public.file-url") {
+            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { item, _ in
+                if let data = item as? Data,
+                   let url = URL(dataRepresentation: data, relativeTo: nil),
+                   let imageData = try? Data(contentsOf: url) {
+                    DispatchQueue.main.async {
+                        if let compressedData = compressImageData(imageData) {
+                            viewModel.setIssueImage(compressedData)
+                        }
+                    }
+                }
+            }
+
+            return true
+        }
+
+        return false
+    }
+
+    func openImagePicker() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+
+        if panel.runModal() == .OK, let url = panel.url {
+            do {
+                let imageData = try Data(contentsOf: url)
+
+                if let compressedData = compressImageData(imageData) {
+                    viewModel.setIssueImage(compressedData)
+                }
+            } catch {
+                LogManager.shared.devLog(.error, "CreateSuggestionView: openImagePicker: error: \(error)")
+            }
+        }
+    }
+#endif
+}
+
+extension CreateSuggestionView {
+    func compressImageData(_ data: Data) -> Data? {
+#if os(iOS)
+        guard let sourceImage = UIImage(data: data) else {
+            return nil
+        }
+
+        return sourceImage.jpegData(compressionQuality: 0.75)
+#elseif os(macOS)
+        guard let sourceImage = NSImage(data: data) else {
+            return nil
+        }
+
+        guard let tiffData = sourceImage.tiffRepresentation, let bitmap = NSBitmapImageRep(data: tiffData) else {
+            return nil
+        }
+
+        return bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.75])
+#else
+        return data
+#endif
+    }
+}

--- a/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionView.swift
+++ b/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionView.swift
@@ -6,6 +6,9 @@
 //  Copyright © 2025 ArtCC. All rights reserved.
 //
 
+#if os(iOS)
+import PhotosUI
+#endif
 import SwiftUI
 
 struct CreateSuggestionView: View {
@@ -15,6 +18,10 @@ struct CreateSuggestionView: View {
     @Environment(\.voticeTheme) private var theme
 
     @StateObject private var viewModel = CreateSuggestionViewModel()
+
+#if os(iOS)
+    @State private var selectedPhotoItem: PhotosPickerItem?
+#endif
 
     @FocusState private var focusedField: Field?
 
@@ -114,7 +121,7 @@ private extension CreateSuggestionView {
             }
             HStack(alignment: .center) {
                 Spacer()
-                Text(TextManager.shared.texts.newSuggestion)
+                Text(viewModel.isIssue ? TextManager.shared.texts.reportIssue : TextManager.shared.texts.newSuggestion)
                     .font(theme.typography.headline)
                     .fontWeight(.medium)
                     .foregroundColor(theme.colors.onBackground)
@@ -157,24 +164,32 @@ private extension CreateSuggestionView {
                             )
                         )
                         .frame(width: 50, height: 50)
-                    Image(systemName: "lightbulb.fill")
+                    Image(systemName: viewModel.isIssue ? "exclamationmark.triangle.fill" : "lightbulb.fill")
                         .font(.system(size: 22))
                         .foregroundStyle(
+                            // swiftlint:disable line_length
                             LinearGradient(
-                                colors: [theme.colors.primary, theme.colors.accent],
+                                colors: viewModel.isIssue ? [theme.colors.warning, theme.colors.accent] : [theme.colors.primary, theme.colors.accent],
                                 startPoint: .topLeading,
                                 endPoint: .bottomTrailing
                             )
+                            // swiftlint:enable line_length
                         )
                 }
                 VStack(alignment: .leading, spacing: 5) {
-                    Text(TextManager.shared.texts.shareYourIdea)
-                        .font(theme.typography.headline)
-                        .fontWeight(.semibold)
-                        .foregroundColor(theme.colors.onSurface)
-                    Text(TextManager.shared.texts.helpUsImprove)
-                        .font(theme.typography.callout)
-                        .foregroundColor(theme.colors.secondary)
+                    Text(
+                        viewModel.isIssue ?
+                        TextManager.shared.texts.reportIssue : TextManager.shared.texts.shareYourIdea
+                    )
+                    .font(theme.typography.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(theme.colors.onSurface)
+                    Text(
+                        viewModel.isIssue ?
+                        TextManager.shared.texts.reportIssueSubtitle : TextManager.shared.texts.helpUsImprove
+                    )
+                    .font(theme.typography.callout)
+                    .foregroundColor(theme.colors.secondary)
                 }
 
                 Spacer()
@@ -193,6 +208,7 @@ private extension CreateSuggestionView {
             titleSection
             descriptionSection
             nicknameSection
+            issueSection
         }
         .padding(theme.spacing.md)
         .background(
@@ -213,12 +229,16 @@ private extension CreateSuggestionView {
                     .fontWeight(.semibold)
                     .foregroundColor(theme.colors.onSurface)
             }
-            TextField(TextManager.shared.texts.titlePlaceholder, text: $viewModel.title)
-                .textFieldStyle(VoticeTextFieldStyle())
-                .focused($focusedField, equals: .title)
-                .onAppear {
-                    focusedField = .title
-                }
+            TextField(
+                viewModel.isIssue ?
+                TextManager.shared.texts.titleIssuePlaceholder : TextManager.shared.texts.titlePlaceholder,
+                text: $viewModel.title
+            )
+            .textFieldStyle(VoticeTextFieldStyle())
+            .focused($focusedField, equals: .title)
+            .onAppear {
+                focusedField = .title
+            }
             HStack {
                 Image(systemName: "info.circle")
                     .foregroundColor(theme.colors.secondary)
@@ -250,21 +270,71 @@ private extension CreateSuggestionView {
                     .cornerRadius(theme.cornerRadius.sm)
             }
             TextField(
-                TextManager.shared.texts.descriptionPlaceholder,
+                viewModel.isIssue ?
+                TextManager.shared.texts.descriptionIssuePlaceholder : TextManager.shared.texts.descriptionPlaceholder,
                 text: $viewModel.description,
                 axis: .vertical
             )
             .textFieldStyle(VoticeTextFieldStyle())
             .lineLimit(3...8)
             .focused($focusedField, equals: .description)
-            HStack {
-                Image(systemName: "info.circle")
-                    .foregroundColor(theme.colors.secondary)
-                    .font(.caption)
-                Text(TextManager.shared.texts.explainWhyUseful)
-                    .font(theme.typography.caption)
-                    .foregroundColor(theme.colors.secondary)
+            if !viewModel.isIssue {
+                HStack {
+                    Image(systemName: "info.circle")
+                        .foregroundColor(theme.colors.secondary)
+                        .font(.caption)
+                    Text(TextManager.shared.texts.explainWhyUseful)
+                        .font(theme.typography.caption)
+                        .foregroundColor(theme.colors.secondary)
+                }
             }
+        }
+    }
+
+    var issueSection: some View {
+        VStack(alignment: .leading, spacing: theme.spacing.sm) {
+            Toggle(isOn: $viewModel.isIssue) {
+                HStack(spacing: theme.spacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(theme.colors.warning)
+                        .font(.headline)
+                    Text(TextManager.shared.texts.reportIssue)
+                        .font(theme.typography.headline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(theme.colors.onSurface)
+                }
+            }
+            .toggleStyle(SwitchToggleStyle(tint: theme.colors.primary))
+
+#if os(iOS)
+            if viewModel.isIssue {
+                PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+                    HStack {
+                        Image(systemName: "paperclip")
+                            .foregroundColor(theme.colors.primary)
+                        Text(TextManager.shared.texts.attachImage)
+                            .font(theme.typography.callout)
+                            .foregroundColor(theme.colors.onSurface)
+                        Spacer()
+                    }
+                    .padding(.horizontal, theme.spacing.md)
+                    .padding(.vertical, theme.spacing.sm)
+                    .background(theme.colors.primary.opacity(0.08))
+                    .cornerRadius(theme.cornerRadius.sm)
+                }
+                .onChange(of: selectedPhotoItem) { _, newValue in
+                    guard let newValue else {
+                        return
+                    }
+
+                    Task {
+                        if let data = try? await newValue.loadTransferable(type: Data.self) {
+                            viewModel.setIssueImage(data)
+                        }
+                    }
+                }
+            }
+#endif
         }
     }
 

--- a/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionView.swift
+++ b/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionView.swift
@@ -314,12 +314,23 @@ private extension CreateSuggestionView {
                         Image(nsImage: nsImage)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
-                            .frame(width: 125, height: 125)
+                            .frame(width: 150, height: 150)
                             .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius.sm))
                             .overlay(
                                 RoundedRectangle(cornerRadius: theme.cornerRadius.sm)
                                     .stroke(theme.colors.primary.opacity(0.3), lineWidth: 1)
                             )
+                            .overlay(alignment: .topTrailing) {
+                                Button {
+                                    viewModel.issueImageData = nil
+                                } label: {
+                                    Image(systemName: "trash.circle.fill")
+                                        .font(.system(size: 25, weight: .semibold))
+                                        .foregroundColor(theme.colors.error)
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                                .offset(x: 7.5, y: -6.5)
+                            }
                     } else {
                         createMacOSImageSelector()
                     }

--- a/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionViewModel.swift
+++ b/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionViewModel.swift
@@ -45,13 +45,18 @@ final class CreateSuggestionViewModel: ObservableObject {
         }
 
         do {
-            let response = try await suggestionUseCase.createSuggestion(title: title,
-                                                                        description: description,
-                                                                        nickname: nickname)
+            let user: UserEntity = ConfigurationManager.shared.user
+            let response = try await suggestionUseCase.createSuggestion(
+                title: title,
+                description: description,
+                nickname: nickname,
+                userIsPremium: user.isPremium
+            )
 
             return response.suggestion
         } catch {
             LogManager.shared.devLog(.error, "CreateSuggestionViewModel: failed to create suggestion: \(error)")
+
             showError()
 
             throw error
@@ -60,9 +65,11 @@ final class CreateSuggestionViewModel: ObservableObject {
 
     func submitSuggestion(onSuccess: @escaping (SuggestionEntity) -> Void) async {
         do {
-            let suggestion = try await createSuggestion(title: title,
-                                                        description: description,
-                                                        nickname: nickname.isEmpty ? nil : nickname)
+            let suggestion = try await createSuggestion(
+                title: title,
+                description: description,
+                nickname: nickname.isEmpty ? nil : nickname
+            )
 
             onSuccess(suggestion)
         } catch {

--- a/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionViewModel.swift
+++ b/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionViewModel.swift
@@ -46,12 +46,15 @@ final class CreateSuggestionViewModel: ObservableObject {
 
         do {
             let user: UserEntity = ConfigurationManager.shared.user
-            let response = try await suggestionUseCase.createSuggestion(
+            let request: CreateSuggestionRequest = .init(
                 title: title,
                 description: description,
                 nickname: nickname,
-                userIsPremium: user.isPremium
+                userIsPremium: user.isPremium,
+                issue: false,
+                urlImage: nil
             )
+            let response = try await suggestionUseCase.createSuggestion(request: request)
 
             return response.suggestion
         } catch {

--- a/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionViewModel.swift
+++ b/Sources/Votice/UI/Views/CreateSuggestion/CreateSuggestionViewModel.swift
@@ -18,12 +18,14 @@ final class CreateSuggestionViewModel: ObservableObject {
     @Published var nickname = ""
     @Published var currentAlert: VoticeAlertEntity?
     @Published var isShowingAlert = false
+    @Published var isIssue = false
+    @Published var issueImageData: Data?
+
+    private let suggestionUseCase: SuggestionUseCaseProtocol
 
     var isFormValid: Bool {
         !title.isEmpty
     }
-
-    private let suggestionUseCase: SuggestionUseCaseProtocol
 
     // MARK: - Init
 
@@ -51,7 +53,7 @@ final class CreateSuggestionViewModel: ObservableObject {
                 description: description,
                 nickname: nickname,
                 userIsPremium: user.isPremium,
-                issue: false,
+                issue: isIssue,
                 urlImage: nil
             )
             let response = try await suggestionUseCase.createSuggestion(request: request)
@@ -64,6 +66,12 @@ final class CreateSuggestionViewModel: ObservableObject {
 
             throw error
         }
+    }
+
+    func setIssueImage(_ data: Data) {
+        issueImageData = data
+
+        LogManager.shared.devLog(.info, "CreateSuggestionViewModel: received image data (\(data.count) bytes)")
     }
 
     func submitSuggestion(onSuccess: @escaping (SuggestionEntity) -> Void) async {
@@ -84,6 +92,8 @@ final class CreateSuggestionViewModel: ObservableObject {
         title = ""
         description = ""
         nickname = ""
+        isIssue = false
+        issueImageData = nil
     }
 }
 

--- a/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailView.swift
+++ b/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailView.swift
@@ -156,7 +156,12 @@ private extension SuggestionDetailView {
         ZStack(alignment: .topTrailing) {
             VStack(alignment: .leading, spacing: theme.spacing.sm) {
                 VStack(spacing: theme.spacing.sm) {
-                    HStack {
+                    HStack(spacing: 5) {
+                        if suggestion.issue {
+                            Image(systemName: "ladybug.fill")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(theme.colors.pending)
+                        }
                         Text(currentSuggestion.displayText)
                             .font(theme.typography.headline)
                             .fontWeight(.semibold)

--- a/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailView.swift
+++ b/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailView.swift
@@ -140,6 +140,9 @@ private extension SuggestionDetailView {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: theme.spacing.xl) {
                 suggestionHeaderCard
+                if currentSuggestion.issue, let urlImage = currentSuggestion.urlImage, !urlImage.isEmpty {
+                    issueImageCard
+                }
                 votingAndStatsCard
                 if ConfigurationManager.shared.commentIsEnabled {
                     commentsSection
@@ -370,6 +373,50 @@ private extension SuggestionDetailView {
                 .frame(maxWidth: .infinity)
             }
         }
+    }
+
+    var issueImageCard: some View {
+        VStack(alignment: .leading, spacing: theme.spacing.sm) {
+            HStack {
+                Image(systemName: "photo")
+                    .foregroundColor(theme.colors.primary)
+                    .font(.headline)
+                Text(TextManager.shared.texts.titleIssueImage)
+                    .font(theme.typography.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(theme.colors.onSurface)
+                Spacer()
+            }
+            .padding(.top, theme.spacing.md)
+            .padding(.horizontal, theme.spacing.md)
+            AsyncImage(url: URL(string: currentSuggestion.urlImage ?? "")) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxHeight: 600)
+                    .cornerRadius(theme.cornerRadius.md)
+            } placeholder: {
+                RoundedRectangle(cornerRadius: theme.cornerRadius.md)
+                    .fill(theme.colors.secondary.opacity(0.1))
+                    .frame(height: 250)
+                    .overlay(
+                        VStack(spacing: theme.spacing.sm) {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: theme.colors.primary))
+                            Text(TextManager.shared.texts.loadingImage)
+                                .font(theme.typography.caption)
+                                .foregroundColor(theme.colors.secondary)
+                        }
+                    )
+            }
+            .padding(.horizontal, theme.spacing.md)
+            .padding(.bottom, theme.spacing.md)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: theme.cornerRadius.lg)
+                .fill(theme.colors.surface)
+                .shadow(color: theme.colors.primary.opacity(0.1), radius: 8, x: 0, y: 4)
+        )
     }
 }
 

--- a/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailView.swift
+++ b/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailView.swift
@@ -140,7 +140,10 @@ private extension SuggestionDetailView {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: theme.spacing.xl) {
                 suggestionHeaderCard
-                if currentSuggestion.issue, let urlImage = currentSuggestion.urlImage, !urlImage.isEmpty {
+                if let issue = currentSuggestion.issue,
+                   let urlImage = currentSuggestion.urlImage,
+                   issue,
+                   !urlImage.isEmpty {
                     issueImageCard
                 }
                 votingAndStatsCard
@@ -160,7 +163,7 @@ private extension SuggestionDetailView {
             VStack(alignment: .leading, spacing: theme.spacing.sm) {
                 VStack(spacing: theme.spacing.sm) {
                     HStack(spacing: 5) {
-                        if suggestion.issue {
+                        if let issue = suggestion.issue, issue {
                             Image(systemName: "ladybug.fill")
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundColor(theme.colors.pending)

--- a/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailViewModel.swift
+++ b/Sources/Votice/UI/Views/SuggestionDetail/SuggestionDetailViewModel.swift
@@ -140,9 +140,7 @@ final class SuggestionDetailViewModel: ObservableObject {
 
             comments.append(response.comment)
 
-            if let current = suggestionEntity {
-                suggestionEntity = current.copyWith(commentCount: (current.commentCount ?? 0) + 1)
-            }
+            suggestionEntity?.commentCount = (suggestionEntity?.commentCount ?? 0) + 1
 
             reload = true
         } catch {
@@ -160,9 +158,7 @@ final class SuggestionDetailViewModel: ObservableObject {
 
             comments.removeAll { $0.id == comment.id }
 
-            if let current = suggestionEntity {
-                suggestionEntity = current.copyWith(commentCount: max((current.commentCount ?? 1) - 1, 0))
-            }
+            suggestionEntity?.commentCount = max((suggestionEntity?.commentCount ?? 1) - 1, 0)
 
             reload = true
         } catch {
@@ -182,11 +178,8 @@ final class SuggestionDetailViewModel: ObservableObject {
 
             currentVote = response.vote != nil ? type : nil
 
-            if let updatedSuggestion = response.suggestion, let current = suggestionEntity {
-                suggestionEntity = current.copyWith(
-                    updatedAt: updatedSuggestion.updatedAt,
-                    voteCount: updatedSuggestion.voteCount
-                )
+            if let updatedSuggestion = response.suggestion {
+                self.suggestionEntity = updatedSuggestion
             }
 
             reload = true

--- a/Sources/Votice/UI/Views/SuggestionList/SuggestionListView.swift
+++ b/Sources/Votice/UI/Views/SuggestionList/SuggestionListView.swift
@@ -89,9 +89,6 @@ struct SuggestionListView: View {
             .frame(minWidth: 800, minHeight: 600)
 #endif
         }
-        .refreshable {
-            await viewModel.refresh()
-        }
     }
 }
 
@@ -174,6 +171,9 @@ private extension SuggestionListView {
         }
         .scrollBounceBehavior(.basedOnSize)
         .scrollDismissesKeyboard(.immediately)
+        .refreshable {
+            await viewModel.refresh()
+        }
     }
 
     var floatingActionButton: some View {

--- a/Sources/Votice/UI/Views/SuggestionList/SuggestionListViewModel.swift
+++ b/Sources/Votice/UI/Views/SuggestionList/SuggestionListViewModel.swift
@@ -94,7 +94,7 @@ final class SuggestionListViewModel: ObservableObject {
 
                 Task {
                     do {
-                        try await versionUseCase.report()
+                        _ = try await versionUseCase.report()
                     } catch {
                         LogManager.shared.devLog(
                             .error, "SuggestionListViewModel: failed to report version usage: \(error)"
@@ -286,7 +286,7 @@ private extension SuggestionListViewModel {
         let mandatory: Set<SuggestionStatusEntity> = [.inProgress, .pending, .completed]
 
         // Combine both sets to get the final allowed statuses
-        var allowed: Set<SuggestionStatusEntity> = visibleOptional.union(mandatory)
+        let allowed: Set<SuggestionStatusEntity> = visibleOptional.union(mandatory)
 
         // If completed suggestions are shown separately, remove 'completed' from allowed statuses
         let showCompletedSeparately = self.showCompletedSeparately

--- a/Sources/Votice/UI/Views/SuggestionList/SuggestionListViewModel.swift
+++ b/Sources/Votice/UI/Views/SuggestionList/SuggestionListViewModel.swift
@@ -219,10 +219,7 @@ final class SuggestionListViewModel: ObservableObject {
             if let updatedSuggestion = response.suggestion,
                let index = allSuggestions.firstIndex(where: { $0.id == suggestionId }) {
 
-                allSuggestions[index] = allSuggestions[index].copyWith(
-                    updatedAt: updatedSuggestion.updatedAt,
-                    voteCount: updatedSuggestion.voteCount
-                )
+                allSuggestions[index] = updatedSuggestion
 
                 applyFilter()
             }

--- a/Sources/Votice/Votice.swift
+++ b/Sources/Votice/Votice.swift
@@ -76,6 +76,13 @@ public struct Votice {
         ConfigurationManager.shared.setOptionalVisibleStatus(accepted: accepted, blocked: blocked, rejected: rejected)
     }
 
+    /// Set the current user information
+    /// - Parameter isPremium: Whether the user has a premium subscription
+    /// - Note: This can be used to customize the UI and features based on the user's subscription status
+    public static func setUserIsPremium(isPremium: Bool) {
+        ConfigurationManager.shared.user = UserEntity(isPremium: isPremium)
+    }
+
     // MARK: - UI Presentation
 
     /// Present the Votice feedback interface

--- a/Tests/VoticeTests/Managers/TextManagerTests.swift
+++ b/Tests/VoticeTests/Managers/TextManagerTests.swift
@@ -93,6 +93,8 @@ struct MockVoticeTexts: VoticeTextsProtocol {
     let attachImage = "Test Attach Image"
     let titleIssueImage = "Test Issue Image"
     let loadingImage = "Test Loading image..."
+    let dragAndDropImage = "Test Drag image here"
+    let or = "Test or"
 }
 
 // MARK: - TextManager Tests
@@ -306,6 +308,8 @@ func testTextManagerMultipleUpdates() async {
         let attachImage = "Joindre une image"
         let titleIssueImage = "Image du problème"
         let loadingImage = "Chargement de l'image..."
+        let dragAndDropImage = "Faites glisser l'image ici"
+        let or = "ou"
     }
 
     let mockTexts2 = AnotherMockTexts()
@@ -386,6 +390,8 @@ func testDefaultVoticeTexts() async {
     #expect(texts.attachImage == "Attach Image")
     #expect(texts.titleIssueImage == "Issue Image")
     #expect(texts.loadingImage == "Loading image...")
+    #expect(texts.dragAndDropImage == "Drag image here")
+    #expect(texts.or == "or")
 }
 
 @Test("DefaultVoticeTexts should be Sendable")

--- a/Tests/VoticeTests/Managers/TextManagerTests.swift
+++ b/Tests/VoticeTests/Managers/TextManagerTests.swift
@@ -91,6 +91,8 @@ struct MockVoticeTexts: VoticeTextsProtocol {
     let titleIssuePlaceholder = "Test Title Issue Placeholder"
     let descriptionIssuePlaceholder = "Test Description Issue Placeholder"
     let attachImage = "Test Attach Image"
+    let titleIssueImage = "Test Issue Image"
+    let loadingImage = "Test Loading image..."
 }
 
 // MARK: - TextManager Tests
@@ -302,6 +304,8 @@ func testTextManagerMultipleUpdates() async {
         let titleIssuePlaceholder = "Entrez un titre bref pour le problème"
         let descriptionIssuePlaceholder = "Décrivez le problème en détail..."
         let attachImage = "Joindre une image"
+        let titleIssueImage = "Image du problème"
+        let loadingImage = "Chargement de l'image..."
     }
 
     let mockTexts2 = AnotherMockTexts()
@@ -380,6 +384,8 @@ func testDefaultVoticeTexts() async {
     #expect(texts.titleIssuePlaceholder == "Enter a brief title for the issue")
     #expect(texts.descriptionIssuePlaceholder == "Describe the issue in detail...")
     #expect(texts.attachImage == "Attach Image")
+    #expect(texts.titleIssueImage == "Issue Image")
+    #expect(texts.loadingImage == "Loading image...")
 }
 
 @Test("DefaultVoticeTexts should be Sendable")

--- a/Tests/VoticeTests/Managers/TextManagerTests.swift
+++ b/Tests/VoticeTests/Managers/TextManagerTests.swift
@@ -88,8 +88,8 @@ struct MockVoticeTexts: VoticeTextsProtocol {
 
     let reportIssue = "Test Report Issue"
     let reportIssueSubtitle = "Test Report Issue Subtitle"
-    let titleIssuePlaceholder = "Enter a brief title for the issue"
-    let descriptionIssuePlaceholder = "Describe the issue in detail..."
+    let titleIssuePlaceholder = "Test Title Issue Placeholder"
+    let descriptionIssuePlaceholder = "Test Description Issue Placeholder"
     let attachImage = "Test Attach Image"
 }
 
@@ -320,7 +320,6 @@ func testTextManagerMultipleUpdates() async {
     let finalTexts = manager.texts
     #expect(finalTexts.cancel == "Cancel")
     #expect(finalTexts.error == "Error")
-    #expect(finalTexts.ok == "Ok")
 }
 // swiftlint:enable function_body_length
 

--- a/Tests/VoticeTests/Managers/TextManagerTests.swift
+++ b/Tests/VoticeTests/Managers/TextManagerTests.swift
@@ -83,6 +83,14 @@ struct MockVoticeTexts: VoticeTextsProtocol {
     let yourNameOptionalCreate = "Test Your Name Create"
     let enterYourNameCreate = "Test Enter Name Create"
     let leaveEmptyAnonymous = "Test Leave Empty"
+
+    // MARK: - Create Issue (optional feature)
+
+    let reportIssue = "Test Report Issue"
+    let reportIssueSubtitle = "Test Report Issue Subtitle"
+    let titleIssuePlaceholder = "Enter a brief title for the issue"
+    let descriptionIssuePlaceholder = "Describe the issue in detail..."
+    let attachImage = "Test Attach Image"
 }
 
 // MARK: - TextManager Tests
@@ -289,6 +297,11 @@ func testTextManagerMultipleUpdates() async {
         let yourNameOptionalCreate = "Votre nom (optionnel)"
         let enterYourNameCreate = "Entrez votre nom"
         let leaveEmptyAnonymous = "Laissez vide pour soumettre anonymement"
+        let reportIssue = "Signaler un problème"
+        let reportIssueSubtitle = "Aidez-nous à le corriger en décrivant le problème rencontré."
+        let titleIssuePlaceholder = "Entrez un titre bref pour le problème"
+        let descriptionIssuePlaceholder = "Décrivez le problème en détail..."
+        let attachImage = "Joindre une image"
     }
 
     let mockTexts2 = AnotherMockTexts()
@@ -361,6 +374,13 @@ func testDefaultVoticeTexts() async {
     #expect(texts.shareYourIdea == "Share your idea")
     #expect(texts.title == "Title (Min. 3 characters)")
     #expect(texts.titlePlaceholder == "Enter a brief title for your suggestion")
+
+    // Create Issue
+    #expect(texts.reportIssue == "Report Issue")
+    #expect(texts.reportIssueSubtitle == "Help us fix it by describing the issue you encountered.")
+    #expect(texts.titleIssuePlaceholder == "Enter a brief title for the issue")
+    #expect(texts.descriptionIssuePlaceholder == "Describe the issue in detail...")
+    #expect(texts.attachImage == "Attach Image")
 }
 
 @Test("DefaultVoticeTexts should be Sendable")

--- a/Tests/VoticeTests/Models/SuggestionEntityTests.swift
+++ b/Tests/VoticeTests/Models/SuggestionEntityTests.swift
@@ -31,7 +31,8 @@ func testSuggestionEntityInitialization() async {
         source: .sdk,
         commentCount: 5,
         voteCount: 10,
-        language: "en"
+        language: "en",
+        userIsPremium: false
     )
 
     // Then
@@ -51,6 +52,7 @@ func testSuggestionEntityInitialization() async {
     #expect(suggestion.commentCount == 5)
     #expect(suggestion.voteCount == 10)
     #expect(suggestion.language == "en")
+    #expect(suggestion.userIsPremium == false)
 }
 
 @Test("SuggestionEntity should initialize with minimal parameters")
@@ -75,6 +77,7 @@ func testSuggestionEntityMinimalInitialization() async {
     #expect(suggestion.commentCount == nil)
     #expect(suggestion.voteCount == nil)
     #expect(suggestion.language == nil)
+    #expect(suggestion.userIsPremium == false)
 }
 
 @Test("SuggestionEntity displayText should return correct value")
@@ -151,7 +154,8 @@ func testSuggestionEntityCopyWith() async {
         text: "Original Text",
         status: .pending,
         source: .sdk,
-        voteCount: 5
+        voteCount: 5,
+        userIsPremium: false
     )
 
     // When
@@ -169,6 +173,7 @@ func testSuggestionEntityCopyWith() async {
     #expect(copied.status == .pending) // Unchanged
     #expect(copied.source == .sdk) // Unchanged
     #expect(copied.voteCount == 10) // Changed
+    #expect(copied.userIsPremium == false) // Unchanged
 }
 
 @Test("SuggestionEntity should be Equatable")
@@ -177,17 +182,20 @@ func testSuggestionEntityEquatable() async {
     let suggestion1 = SuggestionEntity(
         id: "test-id",
         title: "Test Title",
-        status: .pending
+        status: .pending,
+        userIsPremium: false
     )
     let suggestion2 = SuggestionEntity(
         id: "test-id",
         title: "Test Title",
-        status: .pending
+        status: .pending,
+        userIsPremium: false
     )
     let suggestion3 = SuggestionEntity(
         id: "different-id",
         title: "Test Title",
-        status: .pending
+        status: .pending,
+        userIsPremium: false
     )
 
     // When/Then
@@ -198,7 +206,7 @@ func testSuggestionEntityEquatable() async {
 @Test("SuggestionEntity should be Identifiable")
 func testSuggestionEntityIdentifiable() async {
     // Given
-    let suggestion = SuggestionEntity(id: "test-id")
+    let suggestion = SuggestionEntity(id: "test-id", userIsPremium: false)
 
     // When/Then
     #expect(suggestion.id == "test-id")
@@ -228,7 +236,8 @@ func testSuggestionEntityCodable() async throws {
         source: .sdk,
         commentCount: 5,
         voteCount: 10,
-        language: "en"
+        language: "en",
+        userIsPremium: false
     )
 
     // When - Encode
@@ -256,6 +265,7 @@ func testSuggestionEntityCodable() async throws {
     #expect(decoded.commentCount == original.commentCount)
     #expect(decoded.voteCount == original.voteCount)
     #expect(decoded.language == original.language)
+    #expect(decoded.userIsPremium == original.userIsPremium)
 }
 
 @Test("SuggestionEntity should be Sendable")
@@ -264,7 +274,8 @@ func testSuggestionEntitySendable() async {
     let suggestion = SuggestionEntity(
         id: "test-id",
         title: "Test Title",
-        status: .pending
+        status: .pending,
+        userIsPremium: false
     )
 
     // When - This compiles, proving it's Sendable
@@ -274,6 +285,7 @@ func testSuggestionEntitySendable() async {
         _ = suggestion.displayText
         _ = suggestion.isFromSDK
         _ = suggestion.canBeVoted
+        _ = suggestion.userIsPremium
     }
 
     // Then - No assertion needed, compilation proves Sendable conformance

--- a/Tests/VoticeTests/VoticeTests.swift
+++ b/Tests/VoticeTests/VoticeTests.swift
@@ -177,6 +177,11 @@ struct VoticeTests {
             let yourNameOptionalCreate = "Mock Your Name Optional Create"
             let enterYourNameCreate = "Mock Enter Your Name Create"
             let leaveEmptyAnonymous = "Mock Leave Empty Anonymous"
+            let reportIssue = "Test Report Issue"
+            let reportIssueSubtitle = "Test Report Issue Subtitle"
+            let titleIssuePlaceholder = "Enter a brief title for the issue"
+            let descriptionIssuePlaceholder = "Describe the issue in detail..."
+            let attachImage = "Test Attach Image"
         }
 
         Votice.setTexts(MockTexts())

--- a/Tests/VoticeTests/VoticeTests.swift
+++ b/Tests/VoticeTests/VoticeTests.swift
@@ -183,7 +183,10 @@ struct VoticeTests {
             let descriptionIssuePlaceholder = "Describe the issue in detail..."
             let attachImage = "Test Attach Image"
             let titleIssueImage = "Test Issue Image"
-            let loadingImage = "Test Loading image..."        }
+            let loadingImage = "Test Loading image..."
+            let dragAndDropImage = "Test Drag image here"
+            let or = "Test or"
+        }
 
         Votice.setTexts(MockTexts())
 

--- a/Tests/VoticeTests/VoticeTests.swift
+++ b/Tests/VoticeTests/VoticeTests.swift
@@ -182,7 +182,8 @@ struct VoticeTests {
             let titleIssuePlaceholder = "Enter a brief title for the issue"
             let descriptionIssuePlaceholder = "Describe the issue in detail..."
             let attachImage = "Test Attach Image"
-        }
+            let titleIssueImage = "Test Issue Image"
+            let loadingImage = "Test Loading image..."        }
 
         Votice.setTexts(MockTexts())
 


### PR DESCRIPTION
This pull request introduces several new features and improvements to the Votice SDK and its demo projects, focusing on enhanced user configuration, support for premium users, and an optional "report issue" flow with image upload capability. The changes also include updates to localization, error handling, and project configuration for better code quality and maintainability.

**New Features and Enhancements:**

*Premium User Support and Issue Reporting:*
- Added support for marking users as premium via `Votice.setUserIsPremium(isPremium: Bool)`, and updated `CreateSuggestionRequest` and `SuggestionEntity` to include `userIsPremium`, `issue`, and `urlImage` fields for richer suggestion metadata. [[1]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R44-R50) [[2]](diffhunk://#diff-a3e6917bacd53642efcdc215f56f3b667b72bcfc6126a69329c581bfd9c357c5L16-R43) [[3]](diffhunk://#diff-78d4e5a999c3e26414dcf0940c134ca61b0a1a1b8ba9f000225911be21a672afL27-R32)
- Implemented new optional "report issue" flow, including text keys in `VoticeTextsProtocol` and localization for both English and Spanish, as well as new models for image upload requests and responses. [[1]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R86-R97) [[2]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R176-R187) [[3]](diffhunk://#diff-54aefc61040379651d7fc09065d5fedc947dd3daa70392636c1b427df1de3a50R85-R96) [[4]](diffhunk://#diff-ce035f763936eee877d229ce1cde44a9da3fe26ae4a022d8b0555c97512a9a9cR1-R15) [[5]](diffhunk://#diff-718e7784be916138b90c516356ca5715c9ccbcbf1135952426328ed381dcbb04R1-R15)

*Project Configuration and Quality Assurance:*
- Integrated SwiftLint scripts into the Xcode project for both iOS and macOS targets to enforce code style and quality. [[1]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R435) [[2]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R496) [[3]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R808-R845)
- Disabled user script sandboxing for all targets to ensure compatibility with custom build scripts. [[1]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R991) [[2]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R1025) [[3]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R1130) [[4]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R1162)

**SDK Improvements:**

*Core Model and Manager Updates:*
- Updated `ConfigurationManager` and `StorageManager` protocols to conform to `Sendable` for safer concurrency, and made `userDefaults` nonisolated for thread safety. [[1]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R21) [[2]](diffhunk://#diff-d9588a859719c1628970d4d8253b3ad1c0aa302b499144cd691bf01e6c3d3646L11-R11) [[3]](diffhunk://#diff-d9588a859719c1628970d4d8253b3ad1c0aa302b499144cd691bf01e6c3d3646L20-R20)
- Added a general error case to `VoticeError` for improved error reporting. [[1]](diffhunk://#diff-4f17b734ed3660ffdf0a4258d2b63765c904ea5348a30e230e060dfd84fd5aa0R14) [[2]](diffhunk://#diff-4f17b734ed3660ffdf0a4258d2b63765c904ea5348a30e230e060dfd84fd5aa0R24-R25)

**Documentation and Demo Updates:**

*README and Demo Projects:*
- Updated the README to document the new premium user configuration and fixed a typo in the comments section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L266-R282)
- Increased the minimum window size for the macOS demo app for better usability.
- Updated demo project initialization to set the premium user flag appropriately for each platform. [[1]](diffhunk://#diff-d47d0aab046bfd46ce315ad073a1774fb79774a2863195475b8c08f82822f07eR132) [[2]](diffhunk://#diff-8cee61811451c73f0a88006df440c73bf9258bbeaf919e2d56e77cf808727c5aR78) [[3]](diffhunk://#diff-1ec5209d16cbab96499ef54af38f1038042b3a358f0f85d9a908200fa89be8abR80)

**API Versioning:**

*Version Bump:*
- Bumped SDK version to `1.0.10` to reflect new features and API changes. [[1]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R44-R50) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44)

---

**References:**  
[[1]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R44-R50) [[2]](diffhunk://#diff-a3e6917bacd53642efcdc215f56f3b667b72bcfc6126a69329c581bfd9c357c5L16-R43) [[3]](diffhunk://#diff-78d4e5a999c3e26414dcf0940c134ca61b0a1a1b8ba9f000225911be21a672afL27-R32) [[4]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R86-R97) [[5]](diffhunk://#diff-e2f201eda2d11f9639c96859e82553c86e8ce526b56373d10cbb9ec748bfd9a3R176-R187) [[6]](diffhunk://#diff-54aefc61040379651d7fc09065d5fedc947dd3daa70392636c1b427df1de3a50R85-R96) [[7]](diffhunk://#diff-ce035f763936eee877d229ce1cde44a9da3fe26ae4a022d8b0555c97512a9a9cR1-R15) [[8]](diffhunk://#diff-718e7784be916138b90c516356ca5715c9ccbcbf1135952426328ed381dcbb04R1-R15) [[9]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R435) [[10]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R496) [[11]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R808-R845) [[12]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R991) [[13]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R1025) [[14]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R1130) [[15]](diffhunk://#diff-50593de2ef9249410051040e6bde7b6dc28d75ae437a24bd7b51f866bdde8f31R1162) [[16]](diffhunk://#diff-0af1c111e956938eb64dda098b57541708eb687b876db01f14b3cf8dec52d658R21) [[17]](diffhunk://#diff-d9588a859719c1628970d4d8253b3ad1c0aa302b499144cd691bf01e6c3d3646L11-R11) [[18]](diffhunk://#diff-d9588a859719c1628970d4d8253b3ad1c0aa302b499144cd691bf01e6c3d3646L20-R20) [[19]](diffhunk://#diff-4f17b734ed3660ffdf0a4258d2b63765c904ea5348a30e230e060dfd84fd5aa0R14) [[20]](diffhunk://#diff-4f17b734ed3660ffdf0a4258d2b63765c904ea5348a30e230e060dfd84fd5aa0R24-R25) [[21]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[22]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L266-R282) [[23]](diffhunk://#diff-4f04db18e0c52e799a629345abaf25a2377b4acd15fc1a18481aeeca526a5d54L18-R18) [[24]](diffhunk://#diff-d47d0aab046bfd46ce315ad073a1774fb79774a2863195475b8c08f82822f07eR132) [[25]](diffhunk://#diff-8cee61811451c73f0a88006df440c73bf9258bbeaf919e2d56e77cf808727c5aR78) [[26]](diffhunk://#diff-1ec5209d16cbab96499ef54af38f1038042b3a358f0f85d9a908200fa89be8abR80)